### PR TITLE
feat(ConcertoEditor): Added Syntax Highlighting

### DIFF
--- a/src/ConcertoEditor.tsx
+++ b/src/ConcertoEditor.tsx
@@ -25,7 +25,7 @@ export default function ConcertoEditor( {value, onChange} : {value: string, onCh
         const match = ctoErr.match(/Line (\d+) column (\d+)/);
 
         const lineNumber = parseInt(match[1]);
-        const columnNumber = parseInt(match[2]) - 1;
+        const columnNumber = parseInt(match[2]) ;
         monacoEditor?.editor.setModelMarkers(model, "customMarker", [
             {
             startLineNumber: lineNumber,


### PR DESCRIPTION
Added Syntax Highlighting for concerto editor

Preview:
![image](https://github.com/accordproject/template-playground/assets/19428253/b94d2e90-015e-4a44-9194-35a75b0c75fe)
