### PR TITLE
fixed inappropriate favicon to accordproject icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image" href="https://i0.wp.com/accordproject.org/wp-content/uploads/2020/08/cropped-ms-icon-310x310-1.png?fit=512%2C512&ssl=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Template Playground</title>
   </head>


### PR DESCRIPTION
This PR fixes #31 

Playground currently displays an inaccurate favicon. Currently it showcases the logo of Vite. This may cause confusion among users, as it misrepresents the platform's identity.Instead of displaying vite icon the Accord Project icon should be displayed