### PR TITLE
Fix(GUI): white-spacing in monaco editor

### DIFF
--- a/src/ConcertoEditor.tsx
+++ b/src/ConcertoEditor.tsx
@@ -1,90 +1,78 @@
 import * as monaco from '@monaco-editor/react';
 import { editor } from 'monaco-editor';
 
-const options: editor.IStandaloneEditorConstructionOptions = {
+const options:editor.IStandaloneEditorConstructionOptions = {
   minimap: { enabled: false },
-  wordWrap: 'on',
+  wordWrap: "on",
+  automaticLayout:true,
   scrollBeyondLastLine: false,
-};
+}
+const concertoKeywords = ['map','concept','from','optional','default','range','regex','length','abstract','namespace','import', 'enum', 'scalar', 'extends', 'default', 'participant','asset', 'o','identified by','transaction','event'];
+const concertoTypes = ['String','Integer','Double','DateTime','Long','Boolean']
 
-const concertoKeywords = [
-  'map', 'concept', 'from', 'optional', 'default', 'range', 'regex', 'length', 'abstract', 
-  'namespace', 'import', 'enum', 'scalar', 'extends', 'default', 'participant', 'asset', 
-  'o', 'identified by', 'transaction', 'event'
-];
+export default function ConcertoEditor( {value, onChange} : {value: string, onChange?: (value:string|undefined) => void} ) {
 
-const concertoTypes = ['String', 'Integer', 'Double', 'DateTime', 'Long', 'Boolean'];
-
-export default function ConcertoEditor({ value, onChange }: { value: string, onChange?: (value: string | undefined) => void }) {
-
-  function handleEditorWillMount(monaco: monaco.Monaco) {
-    monaco.languages.register({
-      id: 'concerto',
-      extensions: ['.cto'],
-      aliases: ['Concerto', 'concerto'],
-      mimetypes: ['application/vnd.accordproject.concerto'],
-    });
-
-    monaco.languages.setMonarchTokensProvider('concerto', {
-      keywords: concertoKeywords,
-      typeKeywords: concertoTypes,
-      operators: ['=', '{', '}', '@', '"'],
-      symbols: /[=}{@"]+/,
-      escapes: /\\(?:[btnfru"'\\]|\\u[0-9A-Fa-f]{4})/,
-      tokenizer: {
-        root: [
-          { include: '@whitespace' },
-          [/[a-zA-Z_]\w*/, {
-            cases: {
-              '@keywords': 'keyword',
-              '@typeKeywords': 'type',
-              '@default': 'identifier',
+    function handleEditorWillMount(monaco:monaco.Monaco) {
+        monaco.languages.register({
+            id: 'concerto',
+            extensions: ['.cto'],
+            aliases: ['Concerto', 'concerto'],
+            mimetypes: ['application/vnd.accordproject.concerto'],
+        });
+      
+        monaco.languages.setMonarchTokensProvider('concerto', {
+            keywords: concertoKeywords,
+            typeKeywords: concertoTypes,
+            operators: ['=', '{', '}', '@', '"'],
+            symbols: /[=}{@"]+/,
+            escapes: /\\(?:[btnfru"'\\]|\\u[0-9A-Fa-f]{4})/,
+            tokenizer: {
+            root: [
+                { include: '@whitespace' },
+                [/[a-zA-Z_]\w*/, {
+                cases: {
+                    '@keywords': 'keyword',
+                    '@typeKeywords': 'type',
+                    '@default': 'identifier',
+                },
+                }],
+                [/"([^"\\]|\\.)*$/, 'string.invalid'],  // non-terminated string
+                [/"/, 'string', '@string'],
+            ],
+            string: [
+                [/[^\\"]+/, 'string'],
+                [/@escapes/, 'string.escape'],
+                [/\\./, 'string.escape.invalid'],
+                [/"/, 'string', '@pop'],
+            ],
+            whitespace: [
+                [/\s+/, 'white'],
+                [/(\/\/.*)/, 'comment'],
+            ],
             },
-          }],
-          [/"([^"\\]|\\.)*$/, 'string.invalid'],  // non-terminated string
-          [/"/, 'string', '@string'],
-        ],
-        string: [
-          [/[^\\"]+/, 'string'],
-          [/@escapes/, 'string.escape'],
-          [/\\./, 'string.escape.invalid'],
-          [/"/, 'string', '@pop'],
-        ],
-        whitespace: [
-          [/\s+/, 'white'],
-          [/(\/\/.*)/, 'comment'],
-        ],
-      },
-    });
-
-    monaco.editor.defineTheme('concertoTheme', {
-      base: 'vs',
-      inherit: true,
-      rules: [
-        { token: 'keyword', foreground: 'cd2184' },
-        { token: 'type', foreground: '008080' },
-        { token: 'identifier', foreground: '000000' },
-        { token: 'string', foreground: '008000' },
-        { token: 'string.escape', foreground: '800000' },
-        { token: 'comment', foreground: '808080' },
-        { token: 'white', foreground: 'FFFFFF' },
-      ],
-      colors: {},
-    });
-
-    monaco.editor.setTheme('concertoTheme');
-  }
-
-  return (
+        });
+        monaco.editor.defineTheme('concertoTheme', {
+            base: 'vs',
+            inherit: true,
+            rules: [
+            { token: 'keyword', foreground: 'cd2184' },
+            { token: 'type', foreground: '008080' },
+            { token: 'identifier', foreground: '000000' },
+            { token: 'string', foreground: '008000' },
+            { token: 'string.escape', foreground: '800000' },
+            { token: 'comment', foreground: '808080' },
+            { token: 'white', foreground: 'FFFFFF' },
+            ],
+            colors: {},
+        });
+        
+        monaco.editor.setTheme('concertoTheme');
+    }
+  
+    return (
     <div className="editorwrapper">
-      <monaco.Editor
-        options={options}
-        language='concerto'
-        height="60vh"
-        value={value}
-        onChange={onChange}
-        beforeMount={handleEditorWillMount}
-      />
+        <monaco.Editor options={ options }
+        language='concerto' height="60vh" value={value} onChange={onChange} beforeMount={handleEditorWillMount}/>
     </div>
   );
 }

--- a/src/ConcertoEditor.tsx
+++ b/src/ConcertoEditor.tsx
@@ -1,76 +1,90 @@
 import * as monaco from '@monaco-editor/react';
 import { editor } from 'monaco-editor';
 
-const options:editor.IStandaloneEditorConstructionOptions = {
+const options: editor.IStandaloneEditorConstructionOptions = {
   minimap: { enabled: false },
-  wordWrap: "on"
-}
-const concertoKeywords = ['map','concept','from','optional','default','range','regex','length','abstract','namespace','import', 'enum', 'scalar', 'extends', 'default', 'participant','asset', 'o','identified by','transaction','event'];
-const concertoTypes = ['String','Integer','Double','DateTime','Long','Boolean']
+  wordWrap: 'on',
+  scrollBeyondLastLine: false,
+};
 
-export default function ConcertoEditor( {value, onChange} : {value: string, onChange?: (value:string|undefined) => void} ) {
+const concertoKeywords = [
+  'map', 'concept', 'from', 'optional', 'default', 'range', 'regex', 'length', 'abstract', 
+  'namespace', 'import', 'enum', 'scalar', 'extends', 'default', 'participant', 'asset', 
+  'o', 'identified by', 'transaction', 'event'
+];
 
-    function handleEditorWillMount(monaco:monaco.Monaco) {
-        monaco.languages.register({
-            id: 'concerto',
-            extensions: ['.cto'],
-            aliases: ['Concerto', 'concerto'],
-            mimetypes: ['application/vnd.accordproject.concerto'],
-        });
-      
-        monaco.languages.setMonarchTokensProvider('concerto', {
-            keywords: concertoKeywords,
-            typeKeywords: concertoTypes,
-            operators: ['=', '{', '}', '@', '"'],
-            symbols: /[=}{@"]+/,
-            escapes: /\\(?:[btnfru"'\\]|\\u[0-9A-Fa-f]{4})/,
-            tokenizer: {
-            root: [
-                { include: '@whitespace' },
-                [/[a-zA-Z_]\w*/, {
-                cases: {
-                    '@keywords': 'keyword',
-                    '@typeKeywords': 'type',
-                    '@default': 'identifier',
-                },
-                }],
-                [/"([^"\\]|\\.)*$/, 'string.invalid'],  // non-terminated string
-                [/"/, 'string', '@string'],
-            ],
-            string: [
-                [/[^\\"]+/, 'string'],
-                [/@escapes/, 'string.escape'],
-                [/\\./, 'string.escape.invalid'],
-                [/"/, 'string', '@pop'],
-            ],
-            whitespace: [
-                [/\s+/, 'white'],
-                [/(\/\/.*)/, 'comment'],
-            ],
+const concertoTypes = ['String', 'Integer', 'Double', 'DateTime', 'Long', 'Boolean'];
+
+export default function ConcertoEditor({ value, onChange }: { value: string, onChange?: (value: string | undefined) => void }) {
+
+  function handleEditorWillMount(monaco: monaco.Monaco) {
+    monaco.languages.register({
+      id: 'concerto',
+      extensions: ['.cto'],
+      aliases: ['Concerto', 'concerto'],
+      mimetypes: ['application/vnd.accordproject.concerto'],
+    });
+
+    monaco.languages.setMonarchTokensProvider('concerto', {
+      keywords: concertoKeywords,
+      typeKeywords: concertoTypes,
+      operators: ['=', '{', '}', '@', '"'],
+      symbols: /[=}{@"]+/,
+      escapes: /\\(?:[btnfru"'\\]|\\u[0-9A-Fa-f]{4})/,
+      tokenizer: {
+        root: [
+          { include: '@whitespace' },
+          [/[a-zA-Z_]\w*/, {
+            cases: {
+              '@keywords': 'keyword',
+              '@typeKeywords': 'type',
+              '@default': 'identifier',
             },
-        });
-        monaco.editor.defineTheme('concertoTheme', {
-            base: 'vs',
-            inherit: true,
-            rules: [
-            { token: 'keyword', foreground: 'cd2184' },
-            { token: 'type', foreground: '008080' },
-            { token: 'identifier', foreground: '000000' },
-            { token: 'string', foreground: '008000' },
-            { token: 'string.escape', foreground: '800000' },
-            { token: 'comment', foreground: '808080' },
-            { token: 'white', foreground: 'FFFFFF' },
-            ],
-            colors: {},
-        });
-        
-        monaco.editor.setTheme('concertoTheme');
-    }
-  
-    return (
+          }],
+          [/"([^"\\]|\\.)*$/, 'string.invalid'],  // non-terminated string
+          [/"/, 'string', '@string'],
+        ],
+        string: [
+          [/[^\\"]+/, 'string'],
+          [/@escapes/, 'string.escape'],
+          [/\\./, 'string.escape.invalid'],
+          [/"/, 'string', '@pop'],
+        ],
+        whitespace: [
+          [/\s+/, 'white'],
+          [/(\/\/.*)/, 'comment'],
+        ],
+      },
+    });
+
+    monaco.editor.defineTheme('concertoTheme', {
+      base: 'vs',
+      inherit: true,
+      rules: [
+        { token: 'keyword', foreground: 'cd2184' },
+        { token: 'type', foreground: '008080' },
+        { token: 'identifier', foreground: '000000' },
+        { token: 'string', foreground: '008000' },
+        { token: 'string.escape', foreground: '800000' },
+        { token: 'comment', foreground: '808080' },
+        { token: 'white', foreground: 'FFFFFF' },
+      ],
+      colors: {},
+    });
+
+    monaco.editor.setTheme('concertoTheme');
+  }
+
+  return (
     <div className="editorwrapper">
-        <monaco.Editor options={ options }
-        language='concerto' height="60vh" value={value} onChange={onChange} beforeMount={handleEditorWillMount}/>
+      <monaco.Editor
+        options={options}
+        language='concerto'
+        height="60vh"
+        value={value}
+        onChange={onChange}
+        beforeMount={handleEditorWillMount}
+      />
     </div>
   );
 }

--- a/src/JSONEditor.tsx
+++ b/src/JSONEditor.tsx
@@ -1,18 +1,23 @@
 import * as monaco from '@monaco-editor/react';
 import { editor } from 'monaco-editor';
 
-const options:editor.IStandaloneEditorConstructionOptions = {
+const options: editor.IStandaloneEditorConstructionOptions = {
   minimap: { enabled: false },
-  wordWrap: "on",
-  automaticLayout:true
-}
+  wordWrap: 'on',
+  automaticLayout: true,
+  scrollBeyondLastLine: false,
+};
 
-export default function JSONEditor( {value, onChange} : {value: string, onChange?: (value:string|undefined) => void} ) {
-  
-    return (
+export default function JSONEditor({ value, onChange }: { value: string, onChange?: (value: string | undefined) => void }) {
+  return (
     <div className="editorwrapper">
-        <monaco.Editor options={ options }
-        language='json' height="60vh" value={value} onChange={onChange} />
+      <monaco.Editor
+        options={options}
+        language='json'
+        height="60vh"
+        value={value}
+        onChange={onChange}
+      />
     </div>
   );
 }

--- a/src/JSONEditor.tsx
+++ b/src/JSONEditor.tsx
@@ -1,23 +1,19 @@
 import * as monaco from '@monaco-editor/react';
 import { editor } from 'monaco-editor';
 
-const options: editor.IStandaloneEditorConstructionOptions = {
+const options:editor.IStandaloneEditorConstructionOptions = {
   minimap: { enabled: false },
-  wordWrap: 'on',
-  automaticLayout: true,
+  wordWrap: "on",
+  automaticLayout:true,
   scrollBeyondLastLine: false,
-};
+}
 
-export default function JSONEditor({ value, onChange }: { value: string, onChange?: (value: string | undefined) => void }) {
-  return (
+export default function JSONEditor( {value, onChange} : {value: string, onChange?: (value:string|undefined) => void} ) {
+  
+    return (
     <div className="editorwrapper">
-      <monaco.Editor
-        options={options}
-        language='json'
-        height="60vh"
-        value={value}
-        onChange={onChange}
-      />
+        <monaco.Editor options={ options }
+        language='json' height="60vh" value={value} onChange={onChange} />
     </div>
   );
 }

--- a/src/MarkdownEditor.tsx
+++ b/src/MarkdownEditor.tsx
@@ -1,15 +1,21 @@
 import * as monaco from '@monaco-editor/react';
 import { editor } from 'monaco-editor';
 
-const options:editor.IStandaloneEditorConstructionOptions = {
+const options: editor.IStandaloneEditorConstructionOptions = {
   minimap: { enabled: false },
-  wordWrap: "on"
-}
+  wordWrap: 'on',
+  scrollBeyondLastLine: false,
+};
 
-export default function MarkdownEditor( {value, onChange} : {value: string, onChange?: (value:string|undefined) => void} ) {
+export default function MarkdownEditor({ value, onChange }: { value: string, onChange?: (value: string | undefined) => void }) {
   return (
     <div className="editorwrapper">
-        <monaco.Editor options={ options } height="60vh" value={value} onChange={onChange}/>
+      <monaco.Editor
+        options={options}
+        height="60vh"
+        value={value}
+        onChange={onChange}
+      />
     </div>
   );
 }

--- a/src/MarkdownEditor.tsx
+++ b/src/MarkdownEditor.tsx
@@ -1,21 +1,18 @@
 import * as monaco from '@monaco-editor/react';
 import { editor } from 'monaco-editor';
 
-const options: editor.IStandaloneEditorConstructionOptions = {
+const options:editor.IStandaloneEditorConstructionOptions = {
   minimap: { enabled: false },
-  wordWrap: 'on',
+  wordWrap: "on",
+  automaticLayout:true,
   scrollBeyondLastLine: false,
-};
+}
 
-export default function MarkdownEditor({ value, onChange }: { value: string, onChange?: (value: string | undefined) => void }) {
+export default function MarkdownEditor( {value, onChange} : {value: string, onChange?: (value:string|undefined) => void} ) {
   return (
     <div className="editorwrapper">
-      <monaco.Editor
-        options={options}
-        height="60vh"
-        value={value}
-        onChange={onChange}
-      />
+        <monaco.Editor options={ options } 
+        language='markdown' height="60vh" value={value} onChange={onChange}/>
     </div>
   );
 }


### PR DESCRIPTION
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>Addressed an issue where the white-spacing in the Monaco editor was not consistent, it led to disturbance in layout of the template block.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![before_change](https://github.com/accordproject/template-playground/assets/104414141/dd995db2-6595-4457-a0ed-237aeba2f384)
![after_change](https://github.com/accordproject/template-playground/assets/104414141/f25282eb-00c5-4885-ac81-18887728b33a)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
