### PR TITLE
fix(templates): template whitespace, drilled load and auto scroll on template output

### DIFF
--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -1,12 +1,30 @@
-import useAppStore from './store';
+import useAppStore from "./store";
 
 function AgreementHtml() {
-  const agreementHtml = useAppStore((state) => state.agreementHtml)
-  return <div className="column">
-    <h2>Preview Ouput</h2>
-    <p>The result of merging the JSON data with the template. This is AgreementMark converted to HTML.</p>
-    <div className="agreement" dangerouslySetInnerHTML={{ __html: agreementHtml }}/>
-  </div>;
+  const agreementHtml = useAppStore((state) => state.agreementHtml);
+
+  return (
+    <div
+      className="column"
+      style={{
+        border: "1px solid #d9d9d9",
+        borderRadius: "8px",
+        padding: "16px 16px 100px 16px",
+        height: "calc(100vh - 64px)",
+        overflowY: "auto",
+      }}
+    >
+      <h2 style={{ textAlign: "center" }}>Preview Output</h2>
+      <p>
+        The result of merging the JSON data with the template. This is
+        AgreementMark converted to HTML.
+      </p>
+      <div
+        className="agreement"
+        dangerouslySetInnerHTML={{ __html: agreementHtml }}
+      />
+    </div>
+  );
 }
 
 export default AgreementHtml;

--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -1,7 +1,16 @@
+import { useEffect, useState } from "react";
+import { Spin } from "antd";
 import useAppStore from "./store";
 
 function AgreementHtml() {
   const agreementHtml = useAppStore((state) => state.agreementHtml);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (agreementHtml) {
+      setLoading(false);
+    }
+  }, [agreementHtml]);
 
   return (
     <div
@@ -9,20 +18,38 @@ function AgreementHtml() {
       style={{
         border: "1px solid #d9d9d9",
         borderRadius: "8px",
-        padding: "16px 16px 100px 16px",
+        padding: "16px",
         height: "calc(100vh - 64px)",
         overflowY: "auto",
+        display: "flex",
+        flexDirection: "column",
       }}
     >
-      <h2 style={{ textAlign: "center" }}>Preview Output</h2>
-      <p>
-        The result of merging the JSON data with the template. This is
-        AgreementMark converted to HTML.
-      </p>
-      <div
-        className="agreement"
-        dangerouslySetInnerHTML={{ __html: agreementHtml }}
-      />
+      <div style={{ textAlign: "center" }}>
+        <h2>Preview Output</h2>
+        <p>
+          The result of merging the JSON data with the template. This is
+          AgreementMark converted to HTML.
+        </p>
+      </div>
+      {loading ? (
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <Spin tip="Loading..." size="large" />
+        </div>
+      ) : (
+        <div
+          className="agreement"
+          dangerouslySetInnerHTML={{ __html: agreementHtml }}
+          style={{ flex: 1 }}
+        />
+      )}
     </div>
   );
 }

--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -1,16 +1,8 @@
-import { useEffect, useState } from "react";
 import { Spin } from "antd";
 import useAppStore from "./store";
 
-function AgreementHtml() {
+function AgreementHtml({ loading }: { loading: any }) {
   const agreementHtml = useAppStore((state) => state.agreementHtml);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (agreementHtml) {
-      setLoading(false);
-    }
-  }, [agreementHtml]);
 
   return (
     <div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ const App = () => {
     <AntdApp>
       <Layout style={{ minHeight: "100vh" }}>
         <Navbar scrollToExplore={scrollToExplore} />
-        <Content style={{ flex: "1 0 auto" }}>
+        <Content style={{ height: "calc(100vh - 64px)", overflowY: "auto" }}>
           <div
             style={{
               padding: 24,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,50 +56,48 @@ const App = () => {
 
   return (
     <AntdApp>
-      <Layout>
-        <Layout>
-          <Navbar scrollToExplore={scrollToExplore} />
-          <Content>
+      <Layout style={{ minHeight: "100vh" }}>
+        <Navbar scrollToExplore={scrollToExplore} />
+        <Content style={{ flex: "1 0 auto" }}>
+          <div
+            style={{
+              padding: 24,
+              paddingBottom: 100,
+              minHeight: 360,
+              background: colorBgContainer,
+            }}
+          >
+            <Row id="explore">
+              <Col span={4}>
+                <SampleDropdown />
+              </Col>
+              <Col span={18}>
+                <Errors />
+              </Col>
+            </Row>
             <div
               style={{
                 padding: 24,
-                paddingBottom: 100,
                 minHeight: 360,
                 background: colorBgContainer,
               }}
             >
-              <Row id="explore">
-                <Col span={4}>
-                  <SampleDropdown />
+              <Row gutter={24}>
+                <Col span={16}>
+                  <Collapse
+                    defaultActiveKey={activePanel}
+                    onChange={onChange}
+                    items={panels}
+                  />
                 </Col>
-                <Col span={18}>
-                  <Errors />
+                <Col span={8}>
+                  <AgreementHtml />
                 </Col>
               </Row>
-              <div
-                style={{
-                  padding: 24,
-                  minHeight: 360,
-                  background: colorBgContainer,
-                }}
-              >
-                <Row gutter={24}>
-                  <Col span={16}>
-                    <Collapse
-                      defaultActiveKey={activePanel}
-                      onChange={onChange}
-                      items={panels}
-                    />
-                  </Col>
-                  <Col span={8}>
-                    <AgreementHtml />
-                  </Col>
-                </Row>
-              </div>
             </div>
-          </Content>
-          <Footer />
-        </Layout>
+          </div>
+        </Content>
+        <Footer />
       </Layout>
     </AntdApp>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,7 +98,6 @@ const App = () => {
                 </Col>
                 <Col span={8}>
                   <AgreementHtml loading={loading} />{" "}
-                  {/* Pass loading state as a prop */}
                 </Col>
               </Row>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ const App = () => {
           <div
             style={{
               padding: 24,
-              paddingBottom: 100,
+              paddingBottom: 150,
               minHeight: 360,
               background: colorBgContainer,
             }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ const App = () => {
     <AntdApp>
       <Layout style={{ minHeight: "100vh" }}>
         <Navbar scrollToExplore={scrollToExplore} />
-        <Content style={{ height: "calc(100vh - 64px)", overflowY: "auto" }}>
+        <Content style={{ height: "calc(100vh - 14px)", overflowY: "auto" }}>
           <div
             style={{
               padding: 24,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ const App = () => {
     <AntdApp>
       <Layout style={{ minHeight: "100vh" }}>
         <Navbar scrollToExplore={scrollToExplore} />
-        <Content style={{ height: "calc(100vh - 14px)", overflowY: "auto" }}>
+        <Content>
           <div
             style={{
               padding: 24,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,11 @@ import useAppStore from "./store";
 import SampleDropdown from "./SampleDropdown";
 
 const { Content } = Layout;
+
 const App = () => {
   const init = useAppStore((state) => state.init);
   const [activePanel, setActivePanel] = useState<string | string[]>();
+  const [loading, setLoading] = useState(true);
 
   const scrollToExplore = () => {
     const exploreContent = document.getElementById("explore");
@@ -33,7 +35,11 @@ const App = () => {
   };
 
   useEffect(() => {
-    void init();
+    const initializeApp = async () => {
+      await init();
+      setLoading(false);
+    };
+    initializeApp();
   }, [init]);
 
   const panels = [
@@ -69,7 +75,7 @@ const App = () => {
           >
             <Row id="explore">
               <Col span={4}>
-                <SampleDropdown />
+                <SampleDropdown setLoading={setLoading} />
               </Col>
               <Col span={18}>
                 <Errors />
@@ -91,7 +97,8 @@ const App = () => {
                   />
                 </Col>
                 <Col span={8}>
-                  <AgreementHtml />
+                  <AgreementHtml loading={loading} />{" "}
+                  {/* Pass loading state as a prop */}
                 </Col>
               </Row>
             </div>

--- a/src/SampleDropdown.tsx
+++ b/src/SampleDropdown.tsx
@@ -1,12 +1,9 @@
-import { useState } from "react";
 import { Button, Dropdown, Space, message } from "antd";
 import { DownOutlined } from "@ant-design/icons";
 
 import useAppStore from "./store";
 
-function SampleDropdown() {
-  const [loading, setLoading] = useState(false);
-
+function SampleDropdown({ setLoading }: { setLoading: any }) {
   const samples = useAppStore((state) => state.samples);
   const loadSample = useAppStore((state) => state.loadSample);
 
@@ -37,7 +34,7 @@ function SampleDropdown() {
   return (
     <Space>
       <Dropdown menu={menuProps} trigger={["click"]}>
-        <Button loading={loading}>
+        <Button>
           Load Sample <DownOutlined />
         </Button>
       </Dropdown>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,7 +20,6 @@ const CustomFooter: React.FC = () => {
         background: "#1b2540",
         color: "white",
         padding: "80px 50px 20px 50px",
-        marginTop: "auto",
       }}
     >
       <Row justify="space-between" align="top">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,6 +20,7 @@ const CustomFooter: React.FC = () => {
         background: "#1b2540",
         color: "white",
         padding: "80px 50px 20px 50px",
+        marginTop: "auto",
       }}
     >
       <Row justify="space-between" align="top">

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,9 @@ body,
   display: flex;
   flex-direction: column;
 }
+
+#root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,6 @@
 html,
-body,
-#root {
-  height: 100%;
+body {
+  height: 100vh;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-#root {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
+html,
 body,
-html {
+#root {
+  height: 100%;
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-direction: column;
 }


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #72 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Contents of playground base always be at the bottom of the screen. Even if the content is still loading.
- Auto scrolling to the template output section so that the footer and related components does not overflow.
- Drilled load state through all template sample render components.
- Templates preview output new border redesign




### Related Issues
- Issue #72 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
