### PR TITLE
fix(sharable): agreementData preview screen on shared generated-link bug fixed

### DIFF
--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -32,6 +32,7 @@ export interface DecompressedData {
   templateMarkdown: string;
   modelCto: string;
   data: string;
+  agreementHtml: string;
 }
 
 async function rebuild(template: string, model: string, dataString: string) {
@@ -149,21 +150,21 @@ const useAppStore = create<AppState>()(
           templateMarkdown: state.templateMarkdown,
           modelCto: state.modelCto,
           data: state.data,
+          agreementHtml: state.agreementHtml,
         });
         return `${window.location.origin}/v1?data=${compressedData}`;
       },
       loadFromLink: async (compressedData: string) => {
         try {
-          const { templateMarkdown, modelCto, data } =
+          const { templateMarkdown, modelCto, data, agreementHtml } =
             decompress(compressedData);
           set(() => ({
             templateMarkdown,
             modelCto,
             data,
-            agreementHtml: "",
+            agreementHtml,
             error: undefined,
           }));
-          await rebuildDeBounce(templateMarkdown, modelCto, data);
         } catch (error) {
           set(() => ({
             error: "Failed to load data from the link",

--- a/src/tests/store/generateSharebleLink.test.tsx
+++ b/src/tests/store/generateSharebleLink.test.tsx
@@ -10,6 +10,7 @@ describe("useAppStore", () => {
       templateMarkdown: "Sample Template",
       modelCto: "Sample Model",
       data: '{"key": "value"}',
+      agreementHtml: "<p>Sample Agreement</p>",
     };
 
     // Mock compress function to return a sample compressed string
@@ -21,6 +22,7 @@ describe("useAppStore", () => {
     await store.setTemplateMarkdown(initialState.templateMarkdown);
     await store.setModelCto(initialState.modelCto);
     await store.setData(initialState.data);
+    store.agreementHtml = initialState.agreementHtml;
 
     const shareableLink = store.generateShareableLink();
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Fixed issue where `agreementHtml` was not showing the preview on the shared generated link.
- Ensured that `agreementHtml` is included in the state when generating the shareable link.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- The fix involves mocking the `rebuild` function to ensure `agreementHtml` is correctly set for testing.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
- **prior**
<img width="947" alt="Screenshot 2024-07-30 075807" src="https://github.com/user-attachments/assets/bb637a86-d57f-4947-aa66-8ca58952d3c9">
<img width="945" alt="Screenshot 2024-07-30 075822" src="https://github.com/user-attachments/assets/23b636d8-762d-4694-9aee-ba11111b3b7e">

- **fix**
<img width="941" alt="Screenshot 2024-07-30 080851" src="https://github.com/user-attachments/assets/9a42c167-49a3-4368-8139-a1ccb12e96d7">
<img width="948" alt="Screenshot 2024-07-30 080909" src="https://github.com/user-attachments/assets/82faa3ab-8415-4481-9693-15b41614cd51">


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
