### PR TITLE
fix: scroll of Explore button to the footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,8 +29,8 @@ const App = () => {
   const [loading, setLoading] = useState(true);
   const [searchParams] = useSearchParams();
 
-  const scrollToExplore = () => {
-    const exploreContent = document.getElementById("explore");
+  const scrollToFooter = () => {
+    const exploreContent = document.getElementById("footer");
     if (exploreContent) {
       exploreContent.scrollIntoView({ behavior: "smooth" });
     }
@@ -104,7 +104,7 @@ const App = () => {
   return (
     <AntdApp>
       <Layout style={{ minHeight: "100vh" }}>
-        <Navbar scrollToExplore={scrollToExplore} />
+        <Navbar scrollToFooter={scrollToFooter} />
         <Content>
           <Routes>
             <Route

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,7 +118,7 @@ const App = () => {
                     background: backgroundColor,
                   }}
                 >
-                  <Row id="explore">
+                  <Row>
                     <Col xs={24} sm={8}>
                       <Row
                         style={{

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,6 +22,7 @@ const CustomFooter: React.FC = () => {
 
   return (
     <Footer
+      id="footer"
       style={{
         background: "#1b2540",
         color: "white",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -13,7 +13,7 @@ import {
 
 const { useBreakpoint } = Grid;
 
-function Navbar({ scrollToExplore }: { scrollToExplore: any }) {
+function Navbar({ scrollToFooter }: { scrollToFooter: any }) {
   const [hovered, setHovered] = useState<
     null | "home" | "explore" | "help" | "github" | "join"
   >(null);
@@ -142,7 +142,7 @@ function Navbar({ scrollToExplore }: { scrollToExplore: any }) {
               ...menuItemStyle("explore", false),
               cursor: "pointer",
             }}
-            onClick={scrollToExplore}
+            onClick={scrollToFooter}
             onMouseEnter={() => setHovered("explore")}
             onMouseLeave={() => setHovered(null)}
           >

--- a/src/tests/components/Navbar.test.tsx
+++ b/src/tests/components/Navbar.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 const renderNavbar = () => {
   render(
     <MemoryRouter>
-      <Navbar scrollToExplore={() => {}} />
+      <Navbar scrollToFooter={() => {}} />
     </MemoryRouter>
   );
 };


### PR DESCRIPTION
# Closes #106 
Fix the Explore CTA Void on Nav to scroll to the footer.

### Changes
- Change the scrolltoExplore -> scrolltoFooter for Explore button in Nav
- Made changes in testcase

### Screenshots or Video

https://github.com/user-attachments/assets/5173e03e-a6d6-4829-88a7-38c1f7c22eed

### Related Issues
- Issue #106 
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
