### PR TITLE
Fix(Editor Theme): Monaco Editor Dark Mode theme Fixed

### DIFF
--- a/src/editors/MarkdownEditor.tsx
+++ b/src/editors/MarkdownEditor.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense, useMemo, useCallback } from "react";
+import { lazy, Suspense, useMemo, useCallback, useEffect } from "react";
 import useAppStore from "../store/store";
+import { useMonaco } from "@monaco-editor/react";
 
 const MonacoEditor = lazy(() =>
   import("@monaco-editor/react").then((mod) => ({ default: mod.Editor }))
@@ -13,11 +14,35 @@ export default function MarkdownEditor({
   onChange?: (value: string | undefined) => void;
 }) {
   const backgroundColor = useAppStore((state) => state.backgroundColor);
+  const textColor = useAppStore((state) => state.textColor);
+  const monaco = useMonaco();
 
   const themeName = useMemo(
     () => (backgroundColor ? "darkTheme" : "lightTheme"),
     [backgroundColor]
   );
+
+  useEffect(() => {
+    if (monaco) {
+      const defineTheme = (name: string, base: "vs" | "vs-dark") => {
+        monaco.editor.defineTheme(name, {
+          base,
+          inherit: true,
+          rules: [],
+          colors: {
+            "editor.background": backgroundColor,
+            "editor.foreground": textColor,
+            "editor.lineHighlightBorder": "#EDE8DC",
+          },
+        });
+      };
+
+      defineTheme("lightTheme", "vs");
+      defineTheme("darkTheme", "vs-dark");
+
+      monaco.editor.setTheme(themeName);
+    }
+  }, [monaco, backgroundColor, textColor, themeName]);
 
   const editorOptions = {
     minimap: { enabled: false },


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
## Summary
This PR fixes the Monaco Editor's theme issue while toggling dark mode which was mistakenly removed in my PR #128 to ensure consistency with the overall theme I have restored the theme logic again. Apologies for the mistake.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Initiated the `useEffect` block to trigger the theme for the Monaco Editor

### Screenshots or Video
![Screenshot From 2025-03-01 17-51-56](https://github.com/user-attachments/assets/23ed14d4-59f7-4012-8bdd-c18d341ffcce)
![image](https://github.com/user-attachments/assets/f7a7e8a3-f169-4f05-b04b-e24b934060e2)


### Related Issues
- Issue #<NUMBER>
- Pull Request #139

### Author Checklist
- [X] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
