### PR TITLE
fix : Navbar template Playground not displaying correctly on 360px * …

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -133,7 +133,12 @@ function Navbar({ scrollToFooter }: { scrollToFooter: any }) {
               maxWidth: screens.md ? "184.17px" : "36.67px",
             }}
           />
-          <span style={{ color: "white" }}>Template Playground</span>
+          <span style={{
+            color: "white", 
+            lineHeight: "1.2", 
+            fontSize: screens.md ? "16px" : "14px",
+            paddingRight : screens.md? "0" : "10px"
+          }}>Template Playground</span>
         </a>
       </div>
       {screens.md && (


### PR DESCRIPTION
Fix: Navbar Display Issue on 360px × 740px Viewport


Summary

This PR fixes the navbar display issue on a 360px × 740px viewport in the template-playground repository. 
![Screenshot 2025-03-06 014043](https://github.com/user-attachments/assets/650dc198-cebe-4c20-8f54-03ddfb3a735b)

Changes

Fixed navbar responsiveness for small screens
Updated CSS styles to ensure proper alignment and visibility
Flags
<!--- Provide context or concerns a reviewer should be aware of -->
Ensure changes do not break other viewport sizes
Test the fix across multiple devices for consistency

![Screenshot 2025-03-06 025958](https://github.com/user-attachments/assets/f33777bb-3e7a-4d63-9d59-c3c9414c9736)


Related Issues
Author Checklist
 DCO sign-off added using git commit --signoff
 Unit and/or integration tests cover vital changes
 Commits follow [AP format]
 Documentation updated, if necessary
 PR is merging from fork:branchname into main