### PR TITLE
Learn/intro menu bar responsiveness fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ const App = () => {
   .ant-collapse-content-active {
     background-color: ${backgroundColor} !important;
   }
+  
 `;
     document.head.appendChild(style);
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import { useState } from "react";
+import { useEffect } from "react";
 import {
   SidebarContainer,
   SidebarTitle,
@@ -12,14 +14,39 @@ import {
   DividerLine,
 } from "../styles/components/Sidebar";
 import { BulbOutlined } from "@ant-design/icons";
+import { Collapse } from "antd";
+import { DownOutlined } from "@ant-design/icons";
+import styled from "styled-components";
+
 
 const Sidebar: React.FC<{ steps: { title: string; link: string }[] }> = ({
   steps,
 }) => {
+
+  const [isMobile, setIsMobile] = useState<boolean>(window.innerWidth <= 768);
+
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   return (
-    <SidebarContainer>
-      <SidebarTitle>Learning Pathway</SidebarTitle>
+
+
+    <>
+    {isMobile ? (    <Collapse>
+     <Collapse.Panel key={"1"} header={""}>
+
+    <SidebarContainer >
+    
+  
       <SidebarList>
+      <SidebarTitle>Learning Pathway</SidebarTitle>
         {steps.map((step, index) => (
           <SidebarListItem key={index}>
             <SidebarLink
@@ -31,6 +58,8 @@ const Sidebar: React.FC<{ steps: { title: string; link: string }[] }> = ({
           </SidebarListItem>
         ))}
       </SidebarList>
+  
+
       <DividerLine />
       <HelperBox>
         <HelperIcon>
@@ -45,7 +74,53 @@ const Sidebar: React.FC<{ steps: { title: string; link: string }[] }> = ({
           in another tab to experiment as you learn.
         </HelperText>
       </HelperBox>
+
     </SidebarContainer>
+
+    </Collapse.Panel>
+    </Collapse>) : (    
+
+    <SidebarContainer >
+    
+  
+      <SidebarList>
+      <SidebarTitle>Learning Pathway</SidebarTitle>
+        {steps.map((step, index) => (
+          <SidebarListItem key={index}>
+            <SidebarLink
+              to={step.link}
+              className={({ isActive }) => (isActive ? "active" : undefined)}
+            >
+              {step.title}
+            </SidebarLink>
+          </SidebarListItem>
+        ))}
+      </SidebarList>
+  
+
+      <DividerLine />
+      <HelperBox>
+        <HelperIcon>
+          <BulbOutlined />
+        </HelperIcon>
+        <HelperText>
+          Welcome to the Learning Pathway! Use the sidebar to follow the guide.
+          Open the{" "}
+          <Link to="/" target="_blank" rel="noopener noreferrer">
+            Template Playground
+          </Link>{" "}
+          in another tab to experiment as you learn.
+        </HelperText>
+      </HelperBox>
+
+    </SidebarContainer>
+
+)}
+    </>
+
+
+
+  
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,5 @@ body {
   margin: 0;
   padding: 0;
 }
+
+

--- a/src/pages/LearnNow.tsx
+++ b/src/pages/LearnNow.tsx
@@ -6,8 +6,8 @@ import { steps } from "../constants/learningSteps/steps";
 
 const LearnNow: React.FC = () => {
   return (
-    <LearnNowContainer>
-      <Sidebar steps={steps} />
+    <LearnNowContainer >
+      <Sidebar steps={steps}  />
       <Outlet />
     </LearnNowContainer>
   );

--- a/src/styles/components/Sidebar.ts
+++ b/src/styles/components/Sidebar.ts
@@ -8,12 +8,16 @@ export const SidebarContainer = styled.div`
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
   border-radius: 4px;
   position: relative;
-  overflow-y: auto;
+  // overflow-y: auto;
 
   @media (max-width: 768px) {
     width: 100%;
-    height: auto;
+    height: 35vh;
+    margin-bottom:10px
     position: static;
+   
+   
+    
   }
 `;
 
@@ -22,6 +26,8 @@ export const SidebarTitle = styled.h2`
   font-weight: 500;
   margin-bottom: 1rem;
   color: #333;
+
+
 `;
 
 export const SidebarList = styled.ul`

--- a/src/styles/pages/LearnNow.ts
+++ b/src/styles/pages/LearnNow.ts
@@ -2,6 +2,12 @@ import styled from "styled-components";
 
 export const LearnNowContainer = styled.div`
   display: flex;
+
+  @media (max-width:700px){
+  display:flex;
+  flex-direction:column
+  
+  }
 `;
 
 export const SidebarContainer = styled.div`
@@ -27,6 +33,7 @@ export const SidebarContainer = styled.div`
     text-decoration: none;
     color: #333;
   }
+  
 `;
 
 export const ContentContainer = styled.div`


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #172 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Fixed the responsiveness isuue on the smaller screen for the learn route menu bar



### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
BEFORE :
 ![Screenshot 2025-03-06 231615](https://github.com/user-attachments/assets/028925f0-c8ee-472c-ab66-72c83f860795)
AFTER :
 ![Screenshot 2025-03-06 231605](https://github.com/user-attachments/assets/4a95bd6b-281f-40a4-b831-74b113f20346)


### Related Issues
- Issue #172 
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
