### PR TITLE
Responsiveness of navbar at learn route fixed for small devices

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,14 +12,41 @@ import {
   DividerLine,
 } from "../styles/components/Sidebar";
 import { BulbOutlined } from "@ant-design/icons";
+import { useState , useEffect } from "react";
+import { Collapse } from "antd";
+
+
+
+
 
 const Sidebar: React.FC<{ steps: { title: string; link: string }[] }> = ({
   steps,
 }) => {
+
+  const [isMobile, setIsMobile] = useState<boolean>(window.innerWidth <= 768);
+
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   return (
-    <SidebarContainer>
-      <SidebarTitle>Learning Pathway</SidebarTitle>
+
+
+    <>
+    {isMobile ? (    <Collapse>
+     <Collapse.Panel key={"1"} header={""}>
+
+    <SidebarContainer >
+    
+  
       <SidebarList>
+      <SidebarTitle>Learning Pathway</SidebarTitle>
         {steps.map((step, index) => (
           <SidebarListItem key={index}>
             <SidebarLink
@@ -31,6 +58,8 @@ const Sidebar: React.FC<{ steps: { title: string; link: string }[] }> = ({
           </SidebarListItem>
         ))}
       </SidebarList>
+  
+
       <DividerLine />
       <HelperBox>
         <HelperIcon>
@@ -45,8 +74,56 @@ const Sidebar: React.FC<{ steps: { title: string; link: string }[] }> = ({
           in another tab to experiment as you learn.
         </HelperText>
       </HelperBox>
+
     </SidebarContainer>
+
+    </Collapse.Panel>
+    </Collapse>) : (    
+
+    <SidebarContainer >
+    
+  
+      <SidebarList>
+      <SidebarTitle>Learning Pathway</SidebarTitle>
+        {steps.map((step, index) => (
+          <SidebarListItem key={index}>
+            <SidebarLink
+              to={step.link}
+              className={({ isActive }) => (isActive ? "active" : undefined)}
+            >
+              {step.title}
+            </SidebarLink>
+          </SidebarListItem>
+        ))}
+      </SidebarList>
+  
+
+      <DividerLine />
+      <HelperBox>
+        <HelperIcon>
+          <BulbOutlined />
+        </HelperIcon>
+        <HelperText>
+          Welcome to the Learning Pathway! Use the sidebar to follow the guide.
+          Open the{" "}
+          <Link to="/" target="_blank" rel="noopener noreferrer">
+            Template Playground
+          </Link>{" "}
+          in another tab to experiment as you learn.
+        </HelperText>
+      </HelperBox>
+
+    </SidebarContainer>
+
+)}
+    </>
+
+
+
+  
   );
 };
 
 export default Sidebar;
+
+

--- a/src/styles/pages/LearnNow.ts
+++ b/src/styles/pages/LearnNow.ts
@@ -2,6 +2,10 @@ import styled from "styled-components";
 
 export const LearnNowContainer = styled.div`
   display: flex;
+
+  @media(max-width:768px){
+  flex-direction : column;
+  }
 `;
 
 export const SidebarContainer = styled.div`


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Responsiveness of navbar at learn route fixed for small devices
-  Checked on multiple browsers - Chrome , FireFox , Edge.
Before ::
![Screenshot 2025-03-06 231615](https://github.com/user-attachments/assets/5d2c1408-9587-448d-8f05-cb1c68b55f74)
After ::
![Screenshot 2025-03-06 231605](https://github.com/user-attachments/assets/88b9f3f7-019c-4cd1-b430-17c0a804135e)


### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #172 

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
