### PR TITLE
Fix Dark mode setting resets to light mode after page reload

### DIFF
--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -72,14 +72,18 @@ async function rebuild(template: string, model: string, dataString: string) {
 const useAppStore = create<AppState>()(
   immer(
     devtools((set, get) => ({
-      backgroundColor: '#ffffff',
-      textColor: '#121212',
+      backgroundColor: localStorage.getItem("backgroundColor") || "#ffffff",
+      textColor: localStorage.getItem("textColor") || "#121212",
       toggleDarkMode: () => {
         set((state) => {
-          const isDark = state.backgroundColor === '#121212';
+          const isDark = state.backgroundColor === "#121212";
+          const newBackgroundColor = isDark ? "#ffffff" : "#121212";
+          const newTextColor = isDark ? "#121212" : "#ffffff";
+          localStorage.setItem("backgroundColor", newBackgroundColor);
+          localStorage.setItem("textColor", newTextColor);
           return {
-            backgroundColor: isDark ? '#ffffff' : '#121212',
-            textColor: isDark ? '#121212' : '#ffffff',
+            backgroundColor: newBackgroundColor,
+            textColor: newTextColor,
           };
         });
       },


### PR DESCRIPTION
# Closes #191 

### Changes
- Persist dark mode state by initializing `backgroundColor` and `textColor` from localStorage in the store.

### Flags
- Verify that localStorage is available in the browser environment.
- Ensure the persisted values do not conflict with any other global settings.

### Screenshots or Video

Before:

[420204003-d29b4224-f41e-46bb-9b20-189ede11d928.webm](https://github.com/user-attachments/assets/5d7c1ceb-8be6-4bf2-826a-bb5527783f15)




After:

https://github.com/user-attachments/assets/2798d657-51ad-426b-9b20-4d3955fa72a3




### Related Issues
- Issue #191 

### Author Checklist
- [x]  Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [X] Vital features and changes captured in unit and/or integration tests.
- [X] Commit messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format).
- [X] Extend the documentation, if necessary.
- [X] Merging to `main` from `fork:branchname`.
