### PR TITLE
fix(footer): resolve overlapping help icon on large screens

### DIFF
--- a/src/components/FabButton.tsx
+++ b/src/components/FabButton.tsx
@@ -30,8 +30,8 @@ const FloatingFAB = () => {
         bottom: "20px",
         right: "20px",
         zIndex: 1000,
-        marginBottom: "45px",
-        marginRight:"10px"
+        marginBottom: "2.813rem",
+        marginRight: "0.625rem"
       }}
     >
       <Action

--- a/src/components/FabButton.tsx
+++ b/src/components/FabButton.tsx
@@ -30,6 +30,8 @@ const FloatingFAB = () => {
         bottom: "20px",
         right: "20px",
         zIndex: 1000,
+        marginBottom: "45px",
+        marginRight:"10px"
       }}
     >
       <Action


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #199 
<!--- Provide an overall summary of the pull request -->
This PR resolves the overlapping issue between the footer social links and the floating help icon on larger screens by adjusting margins and positioning in the `fabButton` component.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Updated the `fabButton` component to adjust margins and positioning.

### Flags


### Screenshots or Video
**Before (Overlap):**  
https://github.com/user-attachments/assets/9bf02128-5c0c-48a0-93ed-efb15aa6ffe8

**After (Fixed):**  
https://github.com/user-attachments/assets/8fd44ea5-d4f9-4946-b35c-e332b4db74fa


### Related Issues
- Issue #199 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
