### PR TITLE
feat(editor): add undo redo icons to editor - I204

### DIFF
--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -9,7 +9,6 @@ function AgreementHtml({ loading, isModal }: { loading: any; isModal?: boolean }
   const backgroundColor = useAppStore((state) => state.backgroundColor);
   const textColor = useAppStore((state) => state.textColor);
 
-   
   return (
     <div
       className="column preview-component"

--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -37,8 +37,7 @@ function AgreementHtml({ loading, isModal }: { loading: any; isModal?: boolean }
         {!isModal && <FullScreenModal />}
       </div>
       <p style={{ textAlign: "center", color: textColor }}>
-        The result of merging the JSON data with the template. This is
-        AgreementMark converted to HTML.
+        The result of merging the JSON data with the template.
       </p>
       {loading ? (
         <div style={{ flex: 1, display: "flex", justifyContent: "center", alignItems: "center" }}>

--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -37,7 +37,8 @@ function AgreementHtml({ loading, isModal }: { loading: any; isModal?: boolean }
         {!isModal && <FullScreenModal />}
       </div>
       <p style={{ textAlign: "center", color: textColor }}>
-        The result of merging the JSON data with the template.
+        The result of merging the JSON data with the template. This is
+        AgreementMark converted to HTML.
       </p>
       {loading ? (
         <div style={{ flex: 1, display: "flex", justifyContent: "center", alignItems: "center" }}>

--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -1,19 +1,15 @@
+
 import { LoadingOutlined } from "@ant-design/icons";
 import { Spin } from "antd";
 import useAppStore from "./store/store";
 import FullScreenModal from "./components/FullScreenModal";
 
-function AgreementHtml({
-  loading,
-  isModal,
-}: {
-  loading: boolean;
-  isModal?: boolean;
-}) {
+function AgreementHtml({ loading, isModal }: { loading: any; isModal?: boolean }) {
   const agreementHtml = useAppStore((state) => state.agreementHtml);
   const backgroundColor = useAppStore((state) => state.backgroundColor);
   const textColor = useAppStore((state) => state.textColor);
 
+   
   return (
     <div
       className="column preview-component"
@@ -35,49 +31,23 @@ function AgreementHtml({
           color: textColor,
         }}
       >
-        <h2
-          style={{
-            flexGrow: 1,
-            textAlign: "center",
-            paddingLeft: "34px",
-            color: textColor,
-          }}
-        >
+        <h2 style={{ flexGrow: 1, textAlign: "center", paddingLeft: "34px", color: textColor }}>
           Preview Output
         </h2>
         {!isModal && <FullScreenModal />}
       </div>
       <p style={{ textAlign: "center", color: textColor }}>
-        The result of merging the JSON data with the template. This is
-        AgreementMark converted to HTML.
+        The result of merging the JSON data with the template.
       </p>
       {loading ? (
-        <div
-          style={{
-            flex: 1,
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-        >
-          <Spin
-            indicator={
-              <LoadingOutlined
-                style={{ fontSize: 42, color: "#19c6c7" }}
-                spin
-              />
-            }
-          />
+        <div style={{ flex: 1, display: "flex", justifyContent: "center", alignItems: "center" }}>
+          <Spin indicator={<LoadingOutlined style={{ fontSize: 42, color: "#19c6c7" }} spin />} />
         </div>
       ) : (
         <div
           className="agreement"
           dangerouslySetInnerHTML={{ __html: agreementHtml }}
-          style={{
-            flex: 1,
-            color: textColor,
-            backgroundColor: backgroundColor,
-          }}
+          style={{ flex: 1, color: textColor, backgroundColor: backgroundColor }}
         />
       )}
     </div>

--- a/src/components/ToggleDarkMode.tsx
+++ b/src/components/ToggleDarkMode.tsx
@@ -11,7 +11,7 @@ const ToggleDarkMode: React.FC = () => {
     setIsDarkMode(backgroundColor === "#121212");
   }, [backgroundColor]);
 
-  const handleChange = (isChecked: boolean) => {
+  const handleChange = () => {
     toggleDarkMode();
     setIsDarkMode((prev) => !prev);
     const newTheme = !isDarkMode ? "dark" : "light";

--- a/src/components/ToggleDarkMode.tsx
+++ b/src/components/ToggleDarkMode.tsx
@@ -11,7 +11,7 @@ const ToggleDarkMode: React.FC = () => {
     setIsDarkMode(backgroundColor === "#121212");
   }, [backgroundColor]);
 
-  const handleChange = () => {
+  const handleChange = (isChecked: boolean) => {
     toggleDarkMode();
     setIsDarkMode((prev) => !prev);
     const newTheme = !isDarkMode ? "dark" : "light";

--- a/src/components/useUndoRedo.ts
+++ b/src/components/useUndoRedo.ts
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+
+function useUndoRedo<T>(initialValue: T) {
+  const [past, setPast] = useState<T[]>([]);
+  const [present, setPresent] = useState<T>(initialValue);
+  const [future, setFuture] = useState<T[]>([]);
+
+  // Function to update the present state and track past states
+  const set = (newValue: T) => {
+    setPast((prevPast) => [...prevPast, present]);
+    setPresent(newValue);
+    setFuture([]); // Clear future when new change is made
+  };
+
+  const undo = () => {
+    if (past.length === 0) return;
+    const previous = past[past.length - 1];
+    setPast((prevPast) => prevPast.slice(0, -1));
+    setFuture((prevFuture) => [present, ...prevFuture]);
+    setPresent(previous);
+  };
+
+  const redo = () => {
+    if (future.length === 0) return;
+    const next = future[0];
+    setFuture((prevFuture) => prevFuture.slice(1));
+    setPast((prevPast) => [...prevPast, present]);
+    setPresent(next);
+  };
+
+  return { value: present, set, undo, redo };
+}
+
+export default useUndoRedo;

--- a/src/components/useUndoRedo.ts
+++ b/src/components/useUndoRedo.ts
@@ -1,16 +1,14 @@
-import { useState } from "react";
-
-
-function useUndoRedo<T>(initialValue: T) {
+import { useState } from 'react';
+function useUndoRedo<T>(initialValue: T, onChange?: (value: T) => void) {
   const [past, setPast] = useState<T[]>([]);
   const [present, setPresent] = useState<T>(initialValue);
   const [future, setFuture] = useState<T[]>([]);
 
-  // Function to update the present state and track past states
-  const set = (newValue: T) => {
+  const setValue = (newValue: T) => {
     setPast((prevPast) => [...prevPast, present]);
     setPresent(newValue);
-    setFuture([]); // Clear future when new change is made
+    setFuture([]);
+    if (onChange) onChange(newValue); // Ensure preview updates
   };
 
   const undo = () => {
@@ -19,6 +17,7 @@ function useUndoRedo<T>(initialValue: T) {
     setPast((prevPast) => prevPast.slice(0, -1));
     setFuture((prevFuture) => [present, ...prevFuture]);
     setPresent(previous);
+    if (onChange) onChange(previous);
   };
 
   const redo = () => {
@@ -27,9 +26,10 @@ function useUndoRedo<T>(initialValue: T) {
     setFuture((prevFuture) => prevFuture.slice(1));
     setPast((prevPast) => [...prevPast, present]);
     setPresent(next);
+    if (onChange) onChange(next);
   };
 
-  return { value: present, set, undo, redo };
+  return { value: present, setValue, undo, redo };
 }
 
-export default useUndoRedo;
+export default useUndoRedo;

--- a/src/editors/editorsContainer/AgreementData.tsx
+++ b/src/editors/editorsContainer/AgreementData.tsx
@@ -8,7 +8,10 @@ import { FaUndo, FaRedo } from "react-icons/fa";
 function AgreementData() {
   const textColor = useAppStore((state) => state.textColor);
   const setData = useAppStore((state) => state.setData);
-  const { value, set, undo, redo } = useUndoRedo(useAppStore((state) => state.editorAgreementData));
+  const { value, setValue, undo, redo } = useUndoRedo(
+    useAppStore((state) => state.editorAgreementData),
+    setData // Pass setData to update the preview when undo/redo happens
+  );
 
   const debouncedSetData = useCallback(
     debounce((value: string) => {
@@ -19,7 +22,7 @@ function AgreementData() {
 
   const handleChange = (value: string | undefined) => {
     if (value !== undefined) {
-      set(value);
+      setValue(value);
       debouncedSetData(value);
     }
   };

--- a/src/editors/editorsContainer/AgreementData.tsx
+++ b/src/editors/editorsContainer/AgreementData.tsx
@@ -29,8 +29,8 @@ function AgreementData() {
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <h3 style={{ color: textColor }}>Data</h3>
         <div>
-          <FaUndo onClick={undo} style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
-          <FaRedo onClick={redo} style={{ cursor: "pointer", color: textColor }} />
+          <FaUndo onClick={undo} title="Undo" style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
+          <FaRedo onClick={redo} title="Redo" style={{ cursor: "pointer", color: textColor }} />
         </div>
       </div>
       <p style={{ color: textColor }}>

--- a/src/editors/editorsContainer/AgreementData.tsx
+++ b/src/editors/editorsContainer/AgreementData.tsx
@@ -1,15 +1,14 @@
 import JSONEditor from "../JSONEditor";
 import useAppStore from "../../store/store";
+import useUndoRedo from "../../components/useUndoRedo";
 import { useCallback } from "react";
 import { debounce } from "ts-debounce";
+import { FaUndo, FaRedo } from "react-icons/fa";
 
 function AgreementData() {
-  const editorAgreementData = useAppStore((state) => state.editorAgreementData);
-  const setEditorAgreementData = useAppStore(
-    (state) => state.setEditorAgreementData
-  );
-  const setData = useAppStore((state) => state.setData);
   const textColor = useAppStore((state) => state.textColor);
+  const setData = useAppStore((state) => state.setData);
+  const { value, set, undo, redo } = useUndoRedo(useAppStore((state) => state.editorAgreementData));
 
   const debouncedSetData = useCallback(
     debounce((value: string) => {
@@ -20,23 +19,26 @@ function AgreementData() {
 
   const handleChange = (value: string | undefined) => {
     if (value !== undefined) {
-      setEditorAgreementData(value); // Immediate state update
-      debouncedSetData(value); // Debounced state update
+      set(value);
+      debouncedSetData(value);
     }
   };
 
   return (
-    <div className="column">
-      <div className="tooltip">
+    <div className="column" >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <h3 style={{ color: textColor }}>Data</h3>
-        <span style={{ color: textColor }} className="tooltiptext">
-          JSON data (an instance of the Concerto model) used to preview output
-          from the template.
-        </span>
+        <div>
+          <FaUndo onClick={undo} style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
+          <FaRedo onClick={redo} style={{ cursor: "pointer", color: textColor }} />
+        </div>
       </div>
-      <JSONEditor value={editorAgreementData} onChange={handleChange} />
+      <p style={{ color: textColor }}>
+      JSON data (an instance of the Concerto model) used to preview output from the template.
+      </p>
+      <JSONEditor value={value} onChange={handleChange} />
     </div>
   );
 }
 
-export default AgreementData;
+export default AgreementData;

--- a/src/editors/editorsContainer/TemplateMarkdown.tsx
+++ b/src/editors/editorsContainer/TemplateMarkdown.tsx
@@ -9,8 +9,11 @@ function TemplateMarkdown() {
   const textColor = useAppStore((state) => state.textColor);
   const backgroundColor = useAppStore((state) => state.backgroundColor);
   const setTemplateMarkdown = useAppStore((state) => state.setTemplateMarkdown);
-  const { value, set, undo, redo } = useUndoRedo(useAppStore((state) => state.editorValue));
-
+  const { value, setValue, undo, redo } = useUndoRedo(
+    useAppStore((state) => state.editorValue),
+    setTemplateMarkdown // Ensures preview updates when undo/redo happens
+  );
+  
   const debouncedSetTemplateMarkdown = useCallback(
     debounce((value: string) => {
       void setTemplateMarkdown(value);
@@ -20,7 +23,7 @@ function TemplateMarkdown() {
 
   const handleChange = (value: string | undefined) => {
     if (value !== undefined) {
-      set(value);
+      setValue(value);
       debouncedSetTemplateMarkdown(value);
     }
   };

--- a/src/editors/editorsContainer/TemplateMarkdown.tsx
+++ b/src/editors/editorsContainer/TemplateMarkdown.tsx
@@ -30,8 +30,8 @@ function TemplateMarkdown() {
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <h3 style={{ color: textColor }}>TemplateMark</h3>
         <div>
-          <FaUndo onClick={undo} style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
-          <FaRedo onClick={redo} style={{ cursor: "pointer", color: textColor }} />
+          <FaUndo onClick={undo} title="Undo" style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
+          <FaRedo onClick={redo} title="Redo" style={{ cursor: "pointer", color: textColor }} />
         </div>
       </div>
       <p style={{ color: textColor }}>

--- a/src/editors/editorsContainer/TemplateMarkdown.tsx
+++ b/src/editors/editorsContainer/TemplateMarkdown.tsx
@@ -1,37 +1,43 @@
 import MarkdownEditor from "../MarkdownEditor";
 import useAppStore from "../../store/store";
+import useUndoRedo from "../../components/useUndoRedo";
 import { useCallback } from "react";
 import { debounce } from "ts-debounce";
+import { FaUndo, FaRedo } from "react-icons/fa";
 
 function TemplateMarkdown() {
-  const editorValue = useAppStore((state) => state.editorValue);
-  const setEditorValue = useAppStore((state) => state.setEditorValue);
-  const setTemplateMarkdown = useAppStore((state) => state.setTemplateMarkdown);
-  const backgroundColor = useAppStore((state) => state.backgroundColor);
   const textColor = useAppStore((state) => state.textColor);
+  const backgroundColor = useAppStore((state) => state.backgroundColor);
+  const setTemplateMarkdown = useAppStore((state) => state.setTemplateMarkdown);
+  const { value, set, undo, redo } = useUndoRedo(useAppStore((state) => state.editorValue));
 
   const debouncedSetTemplateMarkdown = useCallback(
     debounce((value: string) => {
       void setTemplateMarkdown(value);
     }, 500),
-    []
+    [setTemplateMarkdown]
   );
 
   const handleChange = (value: string | undefined) => {
     if (value !== undefined) {
-      setEditorValue(value);
+      set(value);
       debouncedSetTemplateMarkdown(value);
     }
   };
 
   return (
-    <div className="column" style={{ backgroundColor: backgroundColor }}>
-      <h2 style={{ color: textColor }}>TemplateMark</h2>
+    <div className="column" style={{ backgroundColor }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <h3 style={{ color: textColor }}>TemplateMark</h3>
+        <div>
+          <FaUndo onClick={undo} style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
+          <FaRedo onClick={redo} style={{ cursor: "pointer", color: textColor }} />
+        </div>
+      </div>
       <p style={{ color: textColor }}>
-        A natural language template with embedded variables, conditional
-        sections, and TypeScript code.
+        A natural language template with embedded variables, conditional sections, and TypeScript code.
       </p>
-      <MarkdownEditor value={editorValue} onChange={handleChange} />
+      <MarkdownEditor value={value} onChange={handleChange} />
     </div>
   );
 }

--- a/src/editors/editorsContainer/TemplateModel.tsx
+++ b/src/editors/editorsContainer/TemplateModel.tsx
@@ -8,8 +8,11 @@ import { FaUndo, FaRedo } from "react-icons/fa";
 function TemplateModel() {
   const textColor = useAppStore((state) => state.textColor);
   const setModelCto = useAppStore((state) => state.setModelCto);
-  const { value, set, undo, redo } = useUndoRedo(useAppStore((state) => state.editorModelCto));
-
+  const { value, setValue, undo, redo } = useUndoRedo(
+    useAppStore((state) => state.editorModelCto),
+    setModelCto // Ensures errors and preview update when undo/redo happens
+  );
+  
   const debouncedSetModelCto = useCallback(
     debounce((value: string) => {
       void setModelCto(value);
@@ -19,7 +22,7 @@ function TemplateModel() {
 
   const handleChange = (value: string | undefined) => {
     if (value !== undefined) {
-      set(value);
+      setValue(value);
       debouncedSetModelCto(value);
     }
   };

--- a/src/editors/editorsContainer/TemplateModel.tsx
+++ b/src/editors/editorsContainer/TemplateModel.tsx
@@ -29,8 +29,8 @@ function TemplateModel() {
       <div className="tooltip" style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <h3 style={{ color: textColor }}>Concerto Model</h3>
         <div>
-          <FaUndo onClick={undo} style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
-          <FaRedo onClick={redo} style={{ cursor: "pointer", color: textColor }} />
+          <FaUndo onClick={undo} title="Undo" style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
+          <FaRedo onClick={redo} title="Redo" style={{ cursor: "pointer", color: textColor }} />
         </div>
       </div>
       <span style={{ color: textColor }} className="tooltiptext">

--- a/src/editors/editorsContainer/TemplateModel.tsx
+++ b/src/editors/editorsContainer/TemplateModel.tsx
@@ -1,13 +1,14 @@
 import ConcertoEditor from "../ConcertoEditor";
 import useAppStore from "../../store/store";
+import useUndoRedo from "../../components/useUndoRedo";
 import { useCallback } from "react";
 import { debounce } from "ts-debounce";
+import { FaUndo, FaRedo } from "react-icons/fa";
 
 function TemplateModel() {
-  const editorModelCto = useAppStore((state) => state.editorModelCto);
-  const setEditorModelCto = useAppStore((state) => state.setEditorModelCto);
-  const setModelCto = useAppStore((state) => state.setModelCto);
   const textColor = useAppStore((state) => state.textColor);
+  const setModelCto = useAppStore((state) => state.setModelCto);
+  const { value, set, undo, redo } = useUndoRedo(useAppStore((state) => state.editorModelCto));
 
   const debouncedSetModelCto = useCallback(
     debounce((value: string) => {
@@ -18,22 +19,26 @@ function TemplateModel() {
 
   const handleChange = (value: string | undefined) => {
     if (value !== undefined) {
-      setEditorModelCto(value);
+      set(value);
       debouncedSetModelCto(value);
     }
   };
 
   return (
     <div className="column">
-      <div className="tooltip">
+      <div className="tooltip" style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <h3 style={{ color: textColor }}>Concerto Model</h3>
-        <span style={{ color: textColor }} className="tooltiptext">
-          Defines the data model for the template and its logic.
-        </span>
+        <div>
+          <FaUndo onClick={undo} style={{ cursor: "pointer", color: textColor, marginRight: "8px" }} />
+          <FaRedo onClick={redo} style={{ cursor: "pointer", color: textColor }} />
+        </div>
       </div>
-      <ConcertoEditor value={editorModelCto} onChange={handleChange} />
+      <span style={{ color: textColor }} className="tooltiptext">
+        Defines the data model for the template and its logic.
+      </span>
+      <ConcertoEditor value={value} onChange={handleChange} />
     </div>
   );
 }
 
-export default TemplateModel;
+export default TemplateModel;


### PR DESCRIPTION
# Closes #204 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
- Added **Undo** and **Redo** icons next to the editor headings in `AgreementData.tsx`, `TemplateMarkdown.tsx`, and `TemplateModel.tsx`.
- Implemented undo/redo functionality using `useUndoRedo.ts` for better state management.
- Styled the icons to have a **rectangular box shape with a grey background** for better visibility.
- Ensured all editor headings use the same `<h3>` tag for consistency.

### Screenshots or Video
![Screenshot 2025-03-09 231033](https://github.com/user-attachments/assets/b9aa7071-806b-4b1d-bcd3-4c6195aafbad)
![Screenshot 2025-03-09 231000](https://github.com/user-attachments/assets/930eb327-d876-47d3-8ee5-9f4b9dd81704)


### Related Issues
- Issue #204 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests.
- [x] Commit messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format).
- [x] Extend the documentation, if necessary.
- [x] Merging to `main` from `fork:undo-redo-feature`.


