### PR TITLE
The FAB floating button gets triggered when I am near to its padding area.

### DIFF
--- a/src/components/FabButton.tsx
+++ b/src/components/FabButton.tsx
@@ -2,6 +2,7 @@ import { Fab, Action } from "react-tiny-fab";
 import { MdExplore } from "react-icons/md";
 import { FaCircleQuestion } from "react-icons/fa6";
 import tour from "../components/Tour";
+import FabGlobalStyle from "../styles/components/FabGlobalStyles";
 
 const FloatingFAB = () => {
   const startTourEvent = () => {
@@ -9,57 +10,58 @@ const FloatingFAB = () => {
   };
 
   return (
-    <Fab
-      icon={<FaCircleQuestion />}
-      alwaysShowTitle
-      mainButtonStyles={{
-        backgroundColor: "#1B2540",
-        color: "white",
-        width: "50px",
-        height: "50px",
-        boxShadow: "0px 6px 10px rgba(0, 0, 0, 0.25)",
-        borderRadius: "50%",
-        transition: "all 0.3s ease-in-out",
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        fontSize: "24px",
-      }}
-      style={{
-        position: "fixed",
-        bottom: "20px",
-        right: "20px",
-        zIndex: 1000,
-        marginBottom: "2.813rem",
-        marginRight: "0.625rem"
-      }}
-    >
-      <Action
-        text="Start Tour"
-        onClick={startTourEvent}
-        style={{
-          backgroundColor: "#444444",
+    <>
+      <FabGlobalStyle />
+      <Fab
+        icon={<FaCircleQuestion />}
+        alwaysShowTitle
+        mainButtonStyles={{
+          backgroundColor: "#1B2540",
           color: "white",
-          width: "45px",
-          height: "45px",
+          width: "50px",
+          height: "50px",
+          boxShadow: "0px 6px 10px rgba(0, 0, 0, 0.25)",
+          borderRadius: "50%",
+          transition: "all 0.3s ease-in-out",
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-          borderRadius: "50%",
-          fontSize: "22px",
-          transition: "transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out",
-          boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.2)",
+          fontSize: "24px",
+          padding: "5px",
         }}
-        onMouseEnter={(e) =>
-          (e.currentTarget.style.transform = "scale(1.1)")
-        }
-        onMouseLeave={(e) =>
-          (e.currentTarget.style.transform = "scale(1)")
-        }
+        style={{
+          position: "fixed",
+          bottom: "20px",
+          right: "20px",
+          zIndex: 1000,
+          marginBottom: "2.813rem",
+          marginRight: "0.625rem",
+        }}
       >
-        <MdExplore />
-      </Action>
-    </Fab>
+        <Action
+          text="Start Tour"
+          onClick={startTourEvent}
+          style={{
+            backgroundColor: "#444444",
+            color: "white",
+            width: "45px",
+            height: "45px",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            borderRadius: "50%",
+            fontSize: "22px",
+            transition:
+              "transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out",
+            boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.2)",
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.transform = "scale(1.1)")}
+          onMouseLeave={(e) => (e.currentTarget.style.transform = "scale(1)")}
+        >
+          <MdExplore />
+        </Action>
+      </Fab>
+    </>
   );
 };
 

--- a/src/styles/components/FabGlobalStyles.ts
+++ b/src/styles/components/FabGlobalStyles.ts
@@ -1,0 +1,10 @@
+import { createGlobalStyle } from 'styled-components';
+
+const FabGlobalStyle = createGlobalStyle`
+  .rtf--mb__c {
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+`;
+
+export default FabGlobalStyle;


### PR DESCRIPTION
# Closes #242 
### Changes
- Adjusted the clickable area of the Floating Action Button (FAB) to match its visual boundary, preventing unintended activation when hovering near its padding area

### Flags
- Ensure this change does not interfere with the button's appearance or other UI interactions.
- Verify that the hover effect still works as expected without triggering outside the button's visible area.


### Screenshots or Video
https://github.com/user-attachments/assets/22f5f7d9-c00b-4842-900b-767feee9d2c1


### Related Issues
- Issue #242 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
