### PR TITLE
added editor selection background and foreground color change for mar…

### DIFF
--- a/src/editors/MarkdownEditor.tsx
+++ b/src/editors/MarkdownEditor.tsx
@@ -33,6 +33,11 @@ export default function MarkdownEditor({
             "editor.background": backgroundColor,
             "editor.foreground": textColor,
             "editor.lineHighlightBorder": "#EDE8DC",
+            "editor.selectionBackground":
+              backgroundColor === "#ffffff" ? "#AACCEE" : "#264F78",
+            // Foreground (text) color for selected text
+            "editor.selectionForeground":
+              backgroundColor === "#ffffff" ? "#000000" : "#FFFFFF",
           },
         });
       };


### PR DESCRIPTION
# Partially Closes #245
This pull request partially resolves the issue of poor text selection contrast by modifying the selection background and foreground colors within **one** of the markdown editors. There are three editors, and this change addresses one of them, specifically the main markdown editor.

### Changes
- Updated CSS to change the selection background color to a higher contrast value for better visibility in the main markdown editor.
- Updated CSS to change the selection foreground color to white for improved readability on the new background in the main markdown editor.

### Flags
- This change specifically addresses the issue of poor text selection contrast in the **main markdown editor's** light mode.
- This is a partial resolution, as the issue also exists in the other two editors.
- Further adjustments to color schemes across the application may be needed for complete consistency in both light and dark modes, and for all three editors.

### Screenshots or Video
![Screenshot 2025-03-14 153838](https://github.com/user-attachments/assets/e3505eae-e997-4ffc-b2eb-2372e5a9047f)


### Related Issues
- Issue #245 
- 
### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests (CSS changes may require visual testing)
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary (If there's a style guide, update it)
- [x] Merging to `main` from `fork:Rahulg321/i245/improve-text-selection-light-mode`