### PR TITLE
feat(editor): add auto-save and restart functionality

### DIFF
--- a/src/components/SampleDropdown.tsx
+++ b/src/components/SampleDropdown.tsx
@@ -1,6 +1,6 @@
 import { Button, Dropdown, Space, message, MenuProps } from "antd";
 import { DownOutlined } from "@ant-design/icons";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, useEffect } from "react";
 import useAppStore from "../store/store";
 import { shallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
@@ -10,16 +10,21 @@ function SampleDropdown({
 }: {
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }): JSX.Element {
-  const { samples, loadSample } = useStoreWithEqualityFn(
+  const { samples, loadSample, sampleName } = useStoreWithEqualityFn(
     useAppStore,
     (state) => ({
       samples: state.samples,
       loadSample: state.loadSample as (key: string) => Promise<void>,
+      sampleName: state.sampleName,
     }),
     shallow
   );
 
-  const [selectedSample, setSelectedSample] = useState<string | null>(null);
+  const [selectedSample, setSelectedSample] = useState<string | null>(sampleName);
+
+  useEffect(() => {
+    setSelectedSample(sampleName);
+  }, [sampleName]);
 
   const items: MenuProps["items"] = useMemo(
     () =>

--- a/src/editors/editorsContainer/TemplateMarkdown.tsx
+++ b/src/editors/editorsContainer/TemplateMarkdown.tsx
@@ -2,6 +2,8 @@ import MarkdownEditor from "../MarkdownEditor";
 import useAppStore from "../../store/store";
 import { useCallback } from "react";
 import { debounce } from "ts-debounce";
+import { Button, Tooltip } from "antd";
+import { RedoOutlined } from "@ant-design/icons";
 
 function TemplateMarkdown() {
   const editorValue = useAppStore((state) => state.editorValue);
@@ -24,9 +26,27 @@ function TemplateMarkdown() {
     }
   };
 
+  const resetEditor = useAppStore((state) => state.resetEditor);
+
+  const handleReset = () => {
+    resetEditor();
+  };
+
   return (
     <div className="column" style={{ backgroundColor: backgroundColor }}>
-      <h2 style={{ color: textColor }}>TemplateMark</h2>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h2 style={{ color: textColor }}>TemplateMark</h2>
+        <div>
+          <Tooltip title="Reset to original template">
+            <Button
+              icon={<RedoOutlined />}
+              onClick={handleReset}
+              type="text"
+              style={{ color: textColor }}
+            />
+          </Tooltip>
+        </div>
+      </div>
       <p style={{ color: textColor }}>
         A natural language template with embedded variables, conditional
         sections, and TypeScript code.

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -10,10 +10,28 @@ import { SAMPLES, Sample } from "../samples";
 import * as playground from "../samples/playground";
 import { compress, decompress } from "../utils/compression/compression";
 
+const STORAGE_KEY = 'template-playground-state';
+
+interface StorageState {
+  editorValue: string;
+  sampleName: string;
+  lastSavedAt: string;
+}
+
+const persistState = (state: StorageState) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+};
+
+const loadPersistedState = (): StorageState | null => {
+  const savedState = localStorage.getItem(STORAGE_KEY);
+  return savedState ? JSON.parse(savedState) : null;
+};
+
 interface AppState {
   templateMarkdown: string;
   editorValue: string;
   modelCto: string;
+  lastSavedAt?: string;
   editorModelCto: string;
   data: string;
   editorAgreementData: string;
@@ -25,6 +43,7 @@ interface AppState {
   textColor: string;
   setTemplateMarkdown: (template: string) => Promise<void>;
   setEditorValue: (value: string) => void;
+  resetEditor: () => void;
   setModelCto: (model: string) => Promise<void>;
   setEditorModelCto: (value: string) => void;
   setData: (data: string) => Promise<void>;
@@ -99,12 +118,23 @@ const useAppStore = create<AppState>()(
         if (compressedData) {
           await get().loadFromLink(compressedData);
         } else {
+          const savedState = loadPersistedState();
+          if (savedState) {
+            const { editorValue, sampleName, lastSavedAt } = savedState;
+            set(() => ({
+              editorValue,
+              sampleName,
+              lastSavedAt,
+              templateMarkdown: editorValue
+            }));
+          }
           await get().rebuild();
         }
       },
       loadSample: async (name: string) => {
         const sample = SAMPLES.find((s) => s.NAME === name);
         if (sample) {
+          const lastSavedAt = new Date().toISOString();
           set(() => ({
             sampleName: sample.NAME,
             agreementHtml: undefined,
@@ -115,7 +145,9 @@ const useAppStore = create<AppState>()(
             editorModelCto: sample.MODEL,
             data: JSON.stringify(sample.DATA, null, 2),
             editorAgreementData: JSON.stringify(sample.DATA, null, 2),
+            lastSavedAt
           }));
+          persistState({ editorValue: sample.TEMPLATE, sampleName: sample.NAME, lastSavedAt });
           await get().rebuild();
         }
       },
@@ -141,8 +173,34 @@ const useAppStore = create<AppState>()(
           set(() => ({ error: formatError(error) }));
         }
       },
-      setEditorValue: (value: string) => {
-        set(() => ({ editorValue: value }));
+      setEditorValue: async (value: string) => {
+        set((state) => {
+          state.editorValue = value;
+          state.templateMarkdown = value;
+          state.lastSavedAt = new Date().toISOString();
+          persistState({ editorValue: value, sampleName: state.sampleName, lastSavedAt: state.lastSavedAt });
+          return state;
+        });
+        await get().rebuild();
+      },
+      resetEditor: async () => {
+        localStorage.removeItem(STORAGE_KEY);
+        const currentState = get();
+        const currentSample = SAMPLES.find((s) => s.NAME === currentState.sampleName);
+        if (currentSample) {
+          set(() => ({
+            templateMarkdown: currentSample.TEMPLATE,
+            editorValue: currentSample.TEMPLATE,
+            modelCto: currentSample.MODEL,
+            editorModelCto: currentSample.MODEL,
+            data: JSON.stringify(currentSample.DATA, null, 2),
+            editorAgreementData: JSON.stringify(currentSample.DATA, null, 2),
+            lastSavedAt: new Date().toISOString(),
+            error: undefined,
+            agreementHtml: ""
+          }));
+          await get().rebuild();
+        }
       },
       setModelCto: async (model: string) => {
         const { templateMarkdown, data } = get();


### PR DESCRIPTION
# Closes #235 
<!--- Provide an overall summary of the pull request -->  
This PR introduces Auto-Save Work in the Editor & Restart Button to enhance user experience and prevent accidental data loss.  

### Changes  
<!--- More detailed and granular description of changes -->  
- Implemented auto-save functionality using `localStorage` to retain user progress even after a refresh.  
- Added a "Restart" button to reset the editor back to the original template mockup.  
- Used debouncing to optimize performance and reduce frequent writes to `localStorage`.  


### Flags  
<!--- Provide context or concerns a reviewer should be aware of -->  
- Auto-save stores data in `localStorage`, meaning it persists across sessions.  


### Screenshots or Video  
<!--- Provide an easily accessible demonstration of the changes, if applicable -->  
Before Changes
https://github.com/user-attachments/assets/0e6d88c1-1204-4aa8-8992-828bb8dc6b31


After Changes
https://github.com/user-attachments/assets/0bb47b21-aee1-44b3-be82-a49cafcccec1



### Related Issues  
- Issue #235 

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
