### PR TITLE
Sahilkhan117/i258/fix prevent full reloading (#i258)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -109,8 +109,8 @@ function Navbar({ scrollToFooter }: { scrollToFooter: any }) {
         onMouseEnter={() => setHovered("home")}
         onMouseLeave={() => setHovered(null)}
       >
-        <a
-          href="/"
+        <Link
+          to="/"
           rel="noopener noreferrer"
           style={{ display: "flex", alignItems: "center" }}
         >
@@ -125,7 +125,7 @@ function Navbar({ scrollToFooter }: { scrollToFooter: any }) {
             }}
           />
           <span style={{ color: "white" }}>Template Playground</span>
-        </a>
+        </Link>
       </div>
       {screens.md && (
         <>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -111,7 +111,6 @@ function Navbar({ scrollToFooter }: { scrollToFooter: any }) {
       >
         <Link
           to="/"
-          rel="noopener noreferrer"
           style={{ display: "flex", alignItems: "center" }}
         >
           <Image


### PR DESCRIPTION
# **Closes #258**

This PR fixes the issue where clicking the logo **caused a full page reload** instead of a smooth React Router navigation.

### **Summary**

This pull request addresses the issue where clicking the logo caused a full page reload. By replacing the `<a href="/">` element with `<Link to="/">` from `react-router-dom`, the navigation is now handled smoothly without reloading the page, preserving the React state and ensuring a better user experience.

### **Changes**

1. Replaced `<a href="/">` with `<Link to="/">` from `react-router-dom`.
2. Ensured that the styling and structure of the logo remain intact.
3. Prevented unnecessary reloading of the page, preserving React state.

### **New Code**
```tsx
<Link
  to="/"
  style={{ display: "flex", alignItems: "center" }}
  >
  <Image
  	src={screens.lg ? "/logo.png" : "/accord_logo.png"}
  	alt="Template Playground"
  	preview={false}
  	style={{
  		paddingRight: screens.md ? "24px" : "10px",
  		height: "26px",
  		maxWidth: screens.md ? "184.17px" : "36.67px",
  	}}
  />
  <span style={{ color: "white" }}>Template Playground</span>
</Link>
```

### **Flags**
-   Ensured this change does not break existing navigation behavior.
-   Verified that the logo click now works without triggering a full reload.

### **Resolved Problem Video Demo**
![solution-reloading](https://github.com/user-attachments/assets/63a6a2dd-7636-478c-83cc-8c0ad8c39ca5)

### **Related Issues**
-   **Issue #258**

### **Author Checklist**
-   [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
-   [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format).
-   [x] Merging to `main` from `fork:sahilkhan117/i258/fix-logo-reload`.
