### PR TITLE
feat: Add Skip Button to Tour for Improved Usability

### DIFF
--- a/src/components/Tour.ts
+++ b/src/components/Tour.ts
@@ -3,6 +3,9 @@ import "shepherd.js/dist/css/shepherd.css";
 
 const style = document.createElement("style");
 style.textContent = `
+  .shepherd-button-secondary {
+    background-color: #6c757d !important;
+  }
   .shepherd-button {
     background-color: #050c40 !important; 
     color: white !important;
@@ -23,6 +26,11 @@ tour.addStep({
   text: "Welcome to the Template Playground! This brief tour will help you get acquainted with the key features of the platform.",
   buttons: [
     {
+      text: "Skip",
+      action: tour.cancel,
+      classes: "shepherd-button-secondary",
+    },
+    {
       text: "Next",
       action: tour.next,
     },
@@ -37,6 +45,11 @@ tour.addStep({
     on: "bottom",
   },
   buttons: [
+    {
+      text: "Skip",
+      action: tour.cancel,
+      classes: "shepherd-button-secondary",
+    },
     {
       text: "Next",
       action: tour.next,
@@ -53,6 +66,11 @@ tour.addStep({
   },
   buttons: [
     {
+      text: "Skip",
+      action: tour.cancel,
+      classes: "shepherd-button-secondary",
+    },
+    {
       text: "Next",
       action: tour.next,
     },
@@ -68,6 +86,11 @@ tour.addStep({
   },
   buttons: [
     {
+      text: "Skip",
+      action: tour.cancel,
+      classes: "shepherd-button-secondary",
+    },
+    {
       text: "Next",
       action: tour.next,
     },
@@ -82,6 +105,11 @@ tour.addStep({
     on: "bottom",
   },
   buttons: [
+    {
+      text: "Skip",
+      action: tour.cancel,
+      classes: "shepherd-button-secondary",
+    },
     {
       text: "Next",
       action: tour.next,


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

# Closes #260
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
- Added a "Skip Tour" button to allow users to exit the tour at any time.
- Updated the tour component to display the skip button alongside "Next."
- Ensured that the skip action persists in user preferences.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Check if any additional accessibility improvements are needed.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
(Add screenshots or a short video here)
After changes
https://github.com/user-attachments/assets/cc2a31b6-a294-421c-82b4-34370265102c


### Related Issues
- Issue #260 

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests.
- [ ] Commit messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format).
- [ ] Extend the documentation, if necessary.
- [ ] Merging to `main` from `fork:branchname`.
