### PR TITLE
fix(margin): Align Agreement HTML window with Collapse - I285

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,7 +156,7 @@ const App = () => {
                     }}
                   >
                     <Row gutter={24}>
-                      <Col xs={24} sm={16} style={{ paddingBottom: "20px" }}>
+                      <Col xs={24} sm={16} style={{ paddingBottom: "24px" }}>
                         <Collapse
                           defaultActiveKey={activePanel}
                           onChange={onChange}
@@ -164,12 +164,6 @@ const App = () => {
                         />
                       </Col>
                       <Col xs={24} sm={8}>
-                        <div
-                          style={{
-                            marginBottom: "10px",
-                          }}
-                        >
-                        </div>
                         <AgreementHtml loading={loading} isModal={false} />
                       </Col>
                     </Row>


### PR DESCRIPTION
# Closes #285 
This PR fixes a minor misalignment in Collapse and Agreement HTML window.

### Changes
- Removed the extra div with bottom margin.
- Increased bottom padding of Col containing Collapse for consistent responsive view.

### Screenshots or Video
![image](https://github.com/user-attachments/assets/3f86ea25-3396-443f-ada0-7b79baf65f32)

### Related Issues
- Issue #285 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`