### PR TITLE
fix(modal): Size of Agreement HTML modal - I287

### DIFF
--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -21,7 +21,7 @@ function AgreementHtml({
         border: "1px solid #d9d9d9",
         borderRadius: "8px",
         padding: "16px",
-        height: "calc(100vh - 64px)",
+        height: isModal ? "calc(100vh - 150px)" : "calc(100vh - 64px)",
         overflowY: "auto",
         display: "flex",
         flexDirection: "column",


### PR DESCRIPTION
# Closes #287 
The full screen modal view of Agreement HMTL window has larger size than required due to which a scrollbar appears. Height of Agreement HTML has been adjusted so that the modal fits the screen.

### Changes
- Height of Agreement HTML now depends upon whether it is rendered inside modal or not.

### Screenshots or Video
## Before:
[Modal Scroll.webm](https://github.com/user-attachments/assets/13966841-adca-448c-898e-5296de4e8ed7)
## After:
[Modal Scroll Fixed.webm](https://github.com/user-attachments/assets/e24aae0f-8d2a-4fe1-a67b-c16a3ef4ac74)


### Related Issues
- Issue #287 

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
