### PR TITLE
Fix BeforeMount Typing in ConcertoEditor

### DIFF
--- a/src/editors/ConcertoEditor.tsx
+++ b/src/editors/ConcertoEditor.tsx
@@ -1,4 +1,4 @@
-import { useMonaco } from "@monaco-editor/react";
+import { BeforeMount, useMonaco } from "@monaco-editor/react"; // Import BeforeMount
 import { lazy, Suspense, useCallback, useEffect, useMemo } from "react";
 import * as monaco from "monaco-editor";
 import useAppStore from "../store/store";
@@ -40,7 +40,8 @@ const concertoTypes = [
   "Boolean",
 ];
 
-const handleEditorWillMount = (monacoInstance: typeof monaco) => {
+// Use BeforeMount type instead of typeof monaco
+const handleEditorWillMount: BeforeMount = (monacoInstance) => {
   monacoInstance.languages.register({
     id: "concerto",
     extensions: [".cto"],


### PR DESCRIPTION
### Description
This PR resolves issue #299 by fixing the typing of the `beforeMount` prop in the `ConcertoEditor` component. Previously, the `handleEditorWillMount` function was typed with the overly broad `typeof monaco`, which could lead to TypeScript errors and misalignment with the `@monaco-editor/react` wrapper’s expectations. This change updates the typing to use the specific `BeforeMount` type from `@monaco-editor/react`, improving type safety and ensuring compatibility with the library’s API.

### Changes
- **Updated Import**: Modified the import statement to include `BeforeMount` alongside `useMonaco`:
  - From: `import { useMonaco } from "@monaco-editor/react";`
  - To: `import { BeforeMount, useMonaco } from "@monaco-editor/react";`
- **Fixed Typing**: Changed the `handleEditorWillMount` function’s type from `(monacoInstance: typeof monaco) => void` to `BeforeMount`:
  - From: `const handleEditorWillMount = (monacoInstance: typeof monaco) => { ... };`
  - To: `const handleEditorWillMount: BeforeMount = (monacoInstance) => { ... };`
- **Scope**: No other functional changes were made to the component. The logic inside `handleEditorWillMount` (language registration, token provider, theme setup) remains unchanged, ensuring existing Concerto language support works as before.

### Verification
- **TypeScript Check**: Ran `tsc --noEmit` to confirm no type errors related to `beforeMount` or `handleEditorWillMount`.
- **Runtime Test**: Verified locally that the Monaco Editor initializes with Concerto language support, custom theme, and error highlighting intact.

### Impact
This fix eliminates potential TypeScript compilation errors (e.g., "type mismatch" or "unknown prop type") that could block CI/CD pipelines or confuse developers, as noted in #299. It aligns the component with the `@monaco-editor/react` wrapper’s type definitions, enhancing maintainability.

### Related Issue
Closes #299

### Notes
- The parameter name `monacoInstance` is retained for consistency with the original code, though `BeforeMount` ensures the correct type regardless of naming.
- Tested on a desktop environment (e.g., macOS, Chrome), matching the bug report’s context.