### PR TITLE
feat: Enhance useUndoRedo hook with limit and ref optimization

### DIFF
--- a/src/components/useUndoRedo.ts
+++ b/src/components/useUndoRedo.ts
@@ -1,33 +1,42 @@
-import { useState } from 'react';
-function useUndoRedo<T>(initialValue: T, onChange?: (value: T) => void) {
-  const [past, setPast] = useState<T[]>([]);
+import { useState, useRef, useCallback } from "react";
+
+function useUndoRedo<T>(
+  initialValue: T,
+  onChange?: (value: T) => void,
+  limit = 1000
+) {
+  const pastRef = useRef<T[]>([]);
+  const futureRef = useRef<T[]>([]);
   const [present, setPresent] = useState<T>(initialValue);
-  const [future, setFuture] = useState<T[]>([]);
 
-  const setValue = (newValue: T) => {
-    setPast((prevPast) => [...prevPast, present]);
-    setPresent(newValue);
-    setFuture([]);
-    if (onChange) onChange(newValue); // Ensure preview updates
-  };
+  const setValue = useCallback(
+    (newValue: T) => {
+      pastRef.current.push(present);
+      if (pastRef.current.length > limit) {
+        pastRef.current.shift();
+      }
+      setPresent(newValue);
+      futureRef.current = [];
+      if (onChange) onChange(newValue);
+    },
+    [present, onChange, limit]
+  );
 
-  const undo = () => {
-    if (past.length === 0) return;
-    const previous = past[past.length - 1];
-    setPast((prevPast) => prevPast.slice(0, -1));
-    setFuture((prevFuture) => [present, ...prevFuture]);
+  const undo = useCallback(() => {
+    if (pastRef.current.length === 0) return;
+    const previous = pastRef.current.pop()!;
+    futureRef.current.unshift(present);
     setPresent(previous);
     if (onChange) onChange(previous);
-  };
+  }, [present, onChange]);
 
-  const redo = () => {
-    if (future.length === 0) return;
-    const next = future[0];
-    setFuture((prevFuture) => prevFuture.slice(1));
-    setPast((prevPast) => [...prevPast, present]);
+  const redo = useCallback(() => {
+    if (futureRef.current.length === 0) return;
+    const next = futureRef.current.shift()!;
+    pastRef.current.push(present);
     setPresent(next);
     if (onChange) onChange(next);
-  };
+  }, [present, onChange]);
 
   return { value: present, setValue, undo, redo };
 }


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #312 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Use useRef for past and future states to avoid unnecessary re-renders.
- Add a limit parameter to restrict the maximum number of states stored in the undo stack.
- Use useCallback to memoize the setValue, undo, and redo functions, preventing unnecessary re-renders.


### Related Issues
- Issue #312 
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
