### PR TITLE
fix(Navbar): Update alignment for mobile devices with large aspect ratios (#324)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -115,7 +115,7 @@ function Navbar({ scrollToFooter }: NavbarProps) {
       >
         <Link
           to="/"
-          style={{ display: "flex", alignItems: "center" }}
+          style={{ display: "flex", alignItems: "center", paddingLeft: screens.md ? "": "10px" }}
         >
           <Image
             src={screens.lg ? "/logo.png" : "/accord_logo.png"}
@@ -127,7 +127,7 @@ function Navbar({ scrollToFooter }: NavbarProps) {
               maxWidth: screens.md ? "184.17px" : "36.67px",
             }}
           />
-          <span style={{ color: "white" }}>Template Playground</span>
+          <span style={{ color: "white", display: screens.sm ? "block" : "none"}}>Template Playground</span>
         </Link>
       </div>
       {screens.md && (


### PR DESCRIPTION
# Closes #324 
 
## Update alignment for mobile devices with large aspect ratios

### Changes  
- For small screens uses **`screens.sm`** to hide the `"Template Playground"` text on problematic devices with large aspect ratios.  
- Ensured the change does not disturb the view on other devices, maintaining the existing layout consistency.  

### Flags  
- This fix is specifically targeted at large-aspect-ratio screens and does not affect regular mobile or desktop views.  
- Tested on multiple devices to confirm the layout remains intact.  

### ✅ **Tested Devices List**
This change was verified on the following devices with large aspect ratios:  
- **Samsung Galaxy Z Fold 5** (2176 x 1812, 21.6:18 aspect ratio – inner display)  
- **Samsung Galaxy S20 Ultra** (3200 x 1440, 20:9 aspect ratio)  
- **Samsung Galaxy F13** (2408 x 1080, 20:9 aspect ratio)  
- **Google Pixel 6 Pro** (3120 x 1440, 19.5:9 aspect ratio)  
- **OnePlus 9 Pro** (3216 x 1440, 20.1:9 aspect ratio)  
- **Xiaomi Mi 11 Ultra** (3200 x 1440, 20:9 aspect ratio) 

### Screenshots or Video  
![image](https://github.com/user-attachments/assets/f83214b3-e20a-4450-8e39-5320da2b015d)

### Related Issues  
- Issue Closes #324  

### Author Checklist  
- [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option of git commit.  
- [x] Verified the fix on multiple large-aspect-ratio devices.  
- [x] No documentation updates necessary.  
- [x] Merging to `main` from `fork:sahilkhan117/i324/fix-navbar-for-mobile-layout`. 