### PR TITLE
Sahilkhan117/i328/fix page preview footer layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,8 +143,9 @@ const App = () => {
                 element={
                   <div
                     style={{
-                      padding: 24,
-                      paddingBottom: 150,
+                      padding: screens.md ? 24 : 0,
+                      paddingTop: screens.md ? 24 : 20,
+                      paddingBottom: screens.md ? 150 : 8,
                       minHeight: 360,
                       background: backgroundColor,
                     }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { App as AntdApp, Layout, Row, Col, Collapse, Spin } from "antd";
+import { App as AntdApp, Layout, Row, Col, Collapse, Spin, Grid } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 import { Routes, Route, useSearchParams, useNavigate } from "react-router-dom";
 import Navbar from "./components/Navbar";
@@ -97,6 +97,9 @@ const App = () => {
       startTour();
     }
   }, [searchParams]);
+
+  const { useBreakpoint } = Grid;
+  const screens = useBreakpoint();
 
   const panels = [
     {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,7 +26,7 @@ const CustomFooter: React.FC = () => {
       style={{
         background: "#1b2540",
         color: "white",
-        padding: "50px 50px 20px 50px",
+        padding: screens.md ? "50px 50px 20px 50px" : "30px 20px 20px 20px",
       }}
     >
       <Row justify="space-between" align="middle" gutter={[16, 16]}>


### PR DESCRIPTION
#  Closes #328  

###  **Summary:**  
- Applied **Ant Design's `useBreakpoint()`** with `screen.md` to dynamically reduce padding on smaller screens.  
- Optimized the layout for:  
  - **Main Page** → Reduced excessive padding for better content visibility.  
  - **Template Preview** → Expanded the preview area by decreasing unnecessary whitespace.  
  - **Footer** → Improved spacing and alignment to prevent stacking and hidden links.  
- Ensured the changes **do not affect larger screens**.  

### Changes
- Applied Ant Design's useBreakpoint() hook to detect screen.md and apply responsive padding adjustments.
- Reduced padding on smaller screens to enhance readability and maximize the viewable area.
- Optimized layout for Main Page, Template Preview, and Footer by dynamically adjusting padding based on screen size.
- Verified that the layout remains consistent on larger screens.

| Template Preview                  | Footer                     |
|----------------------------------|----------------------------------|
| ![image](https://github.com/user-attachments/assets/5f094b0e-dd5d-4dc1-9481-9c5a4dafc233) | ![image](https://github.com/user-attachments/assets/ac18d141-6ad5-4429-a200-64e5344bd2b7) |

###  **Tested on Devices:**  
- **Samsung Galaxy Z Fold 5**  
- **Samsung Galaxy S20 Ultra**  
- **Samsung Galaxy F13**  
- **Google Pixel 6 Pro**  
- **OnePlus 9 Pro**  
- **Xiaomi Mi 11 Ultra** 

### Related Issues
- Issue #328
- Related PR: #324 
- Previous PR: #325

### Flags
-  This solution ensures that the reduced padding only applies to smaller screens, keeping the larger-screen layout unaffected.
	
### **Author Checklist:**  
- [x] DCO sign-off included  
- [x] Verified on multiple devices  
- [x] Ready for merging into `main` from `fork:sahilkhan117/i328/fix-page-preview-footer-layout`  

@DianaLease can you please review my PR and Let me know if there is any changes or corrections regarding this problem.