### PR TITLE
fix(learning page): for mobile devices fix sidebar and learning page layout

### DIFF
--- a/src/styles/pages/LearnNow.ts
+++ b/src/styles/pages/LearnNow.ts
@@ -2,6 +2,10 @@ import styled from "styled-components";
 
 export const LearnNowContainer = styled.div`
   display: flex;
+
+  @media (max-width: 767px) {
+    flex-direction: column;
+  }
 `;
 
 export const SidebarContainer = styled.div`

--- a/src/styles/pages/LearnNow.ts
+++ b/src/styles/pages/LearnNow.ts
@@ -42,4 +42,9 @@ export const ContentContainer = styled.div`
   padding: 20px;
   background-color: var(--bg-color) !important; 
   color: var(--text-color) !important;
+
+  @media (max-width: 767px) {
+    margin-top: 25px;
+    margin-bottom: 30px;
+  }
 `;

--- a/src/styles/pages/LearnNow.ts
+++ b/src/styles/pages/LearnNow.ts
@@ -46,5 +46,8 @@ export const ContentContainer = styled.div`
   @media (max-width: 767px) {
     margin-top: 25px;
     margin-bottom: 30px;
+
+    h1 {
+      margin-top: 0;
   }
 `;

--- a/src/styles/pages/LearnNow.ts
+++ b/src/styles/pages/LearnNow.ts
@@ -31,6 +31,10 @@ export const SidebarContainer = styled.div`
     text-decoration: none;
     color: var(--text-color) !important; 
   }
+
+  @media (max-width: 767px) {
+    display: none;
+  }
 `;
 
 export const ContentContainer = styled.div`


### PR DESCRIPTION
# Closes #331 

## **Layout(Learning Page): Remove Sidebar for Better Usability on Mobile Screens**

## **Changes**
-  Removed the **sidebar** on smaller screens to enhance readability and usability.  
-  Applied **full-width content layout** for better presentation on mobile devices.  
-  Improved navigation visibility by ensuring `Previous` and `Next` buttons are always accessible.  
-  Added proper padding and spacing for a clean, readable appearance.  

## 📸 **Screenshots**
| Before                     | After                      |
|-----------------------------|----------------------------|
| ![Screenshot 2025-03-26 162456](https://github.com/user-attachments/assets/9bc204d8-6e48-46cf-936e-311546027c04) | ![Screenshot 2025-03-26 162400](https://github.com/user-attachments/assets/2fa70c0d-57da-4df2-8ffb-59199f598826) |

### **Test Devices**  
- **Samsung Galaxy Z Fold 5**  
- **Samsung Galaxy S20 Ultra**  
- **Google Pixel 6 Pro**  
- **iPhone 13 Pro Max**  
- **OnePlus 9 Pro**  
- **Xiaomi Mi 11 Ultra**  

##  **Flags**
-  This solution **removes the sidebar** only on mobile screens while keeping it on larger screens.  
-  The changes were tested on multiple devices to ensure consistent appearance.  

## 🔗 **Related Issues**
- Issue #329  
- Related PR: #328  

## Code Added
for sidebar
```css
@media (max-width: 767px) {
    display: none;
}
```
for main learning block
```css
@media (max-width: 767px) {
    margin-top: 25px;
    margin-bottom: 30px;
    h1 {
      margin-top: 0;
}
```

## **Author Checklist**
- [x] DCO sign-off included  
- [x] Verified on multiple devices  
- [x] Ready for merging into `main` from `fork:sahilkhan117/i331/fix-learn-page-layout` 

@DianaLease can you please review my PR and Let me know if there is any changes or corrections regarding this problem.