### PR TITLE
Corrected helper text link color

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,15 +8,32 @@ import {
   SidebarLink,
   HelperBox,
   HelperIcon,
-  HelperText,
   DividerLine,
 } from "../styles/components/Sidebar";
 import { BulbOutlined } from "@ant-design/icons";
+import styled from "styled-components";
 
 interface SidebarProps {
   steps: { title: string; link: string }[];
 }
 const Sidebar: React.FC<SidebarProps> = ({ steps }) => {
+  const HelperText = styled.div`
+  flex: 1;
+  color: #333;
+
+  a {
+    color: #19c6c7 !important;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  & > a {
+    margin-left: 0.25rem;
+  }
+`;
   return (
     <SidebarContainer>
       <SidebarTitle>Learning Pathway</SidebarTitle>

--- a/src/styles/components/Sidebar.ts
+++ b/src/styles/components/Sidebar.ts
@@ -76,23 +76,6 @@ export const HelperIcon = styled.div`
   color: #19c6c7;
 `;
 
-export const HelperText = styled.div`
-  flex: 1;
-  color: #333;
-
-  a {
-    color: #19c6c7 !important;
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  & > a {
-    margin-left: 0.25rem;
-  }
-`;
 
 export const DividerLine = styled.div`
   height: 1px;


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

# Closes #334 
<!--- Provide an overall summary of the pull request -->
This PR fixes the issue where the **Template Playground** link inside the `HelperText` component had inconsistent colors across dark and light themes. The link now properly retains its cyan (`#19c6c7`) color in both themes.

### Changes
<!--- More detailed and granular description of changes -->
- **Fixed** link color by explicitly setting `color: #19c6c7 !important;` to override inherited styles.
- **Ensured** that dark mode does not override the link color.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- **Verify that no global CSS overrides are affecting the link styles.**
- **Ensure the cyan color remains visible in both themes with accessibility in mind.**

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->


#### **Fixed Appearance**
![Screenshot 2025-03-28 031247](https://github.com/user-attachments/assets/7582060a-fd8a-4f4c-9843-0dbf45c31b5f)
![Screenshot 2025-03-28 031259](https://github.com/user-attachments/assets/a694a6ef-6221-4fa4-9573-91bf50fd999e)




### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests.
- [ ] Commit messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format).
- [ ] Extend the documentation, if necessary.
- [ ] Merging to `main` from `fork:branchname`.

