### PR TITLE
Persist dark/light mode across page reloads

### DIFF
--- a/src/components/ToggleDarkMode.tsx
+++ b/src/components/ToggleDarkMode.tsx
@@ -8,8 +8,9 @@ const ToggleDarkMode: React.FC = () => {
   const [isDarkMode, setIsDarkMode] = useState(backgroundColor === "#121212");
 
   useEffect(() => {
-    setIsDarkMode(backgroundColor === "#121212");
-  }, [backgroundColor]);
+    const savedTheme = localStorage.getItem('theme');
+    setIsDarkMode(savedTheme === 'dark');
+  }, []);
 
   const handleChange = () => {
     toggleDarkMode();

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -87,6 +87,21 @@ const useAppStore = create<AppState>()(
       init: async () => {
         const params = new URLSearchParams(window.location.search);
         const compressedData = params.get("data");
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark') {
+          set(() => ({
+            backgroundColor: '#121212',
+            textColor: '#ffffff',
+          }));
+          document.documentElement.setAttribute("data-theme", "dark");
+        }
+        else {
+          set(() => ({
+            backgroundColor: '#ffffff',
+            textColor: '#121212',
+          }));
+          document.documentElement.setAttribute("data-theme", "light");
+        }
         if (compressedData) {
           await get().loadFromLink(compressedData);
         } else {
@@ -197,9 +212,14 @@ const useAppStore = create<AppState>()(
       toggleDarkMode: () => {
         set((state) => {
           const isDark = state.backgroundColor === '#121212';
+          const newBackgroundColor = isDark ? '#ffffff' : '#121212';
+          const newTextColor = isDark ? '#121212' : '#ffffff';
+
+          localStorage.setItem('theme', isDark ? 'light' : 'dark');
+      
           return {
-            backgroundColor: isDark ? '#ffffff' : '#121212',
-            textColor: isDark ? '#121212' : '#ffffff',
+            backgroundColor: newBackgroundColor,
+            textColor: newTextColor,
           };
         });
       },


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #336 
<!--- Provide an overall summary of the pull request -->
Persist Dark/Light Mode Across Page Reloads

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added functionality to store the user's theme preference (dark or light) in localStorage.
- Modified app initialization to apply the saved theme preference on page load.
- Updated the data-theme attribute dynamically to ensure consistent styling.
### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Ensure the solution works across all pages and edge cases (e.g., first-time visitors).
- Verify that the localStorage implementation does not conflict with other features.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![Screenshot 2025-03-28 050710](https://github.com/user-attachments/assets/62a509e3-2226-4b49-a252-f6ef9b45062d)
![Screenshot 2025-03-28 050721](https://github.com/user-attachments/assets/0cc34fd5-b7c0-4081-8573-43244dc7c505)


### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
