### PR TITLE
Surya4419/i330/unnecessary re render on sample selection

### DIFF
--- a/src/components/SampleDropdown.tsx
+++ b/src/components/SampleDropdown.tsx
@@ -1,26 +1,27 @@
 import React from "react";
 import { Button, Dropdown, Space, message, MenuProps } from "antd";
 import { DownOutlined } from "@ant-design/icons";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import useAppStore from "../store/store";
 import { shallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
-const SampleDropdown = React.memo(function SampleDropdown({
+const SampleDropdown = function SampleDropdown({
   setLoading,
 }: {
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }): JSX.Element {
-  const { samples, loadSample } = useStoreWithEqualityFn(
+  const { samples, loadSample, sampleName } = useStoreWithEqualityFn(
     useAppStore,
     (state) => ({
       samples: state.samples,
       loadSample: state.loadSample as (key: string) => Promise<void>,
+      sampleName: state.sampleName
     }),
     shallow
   );
 
-  const [selectedSample, setSelectedSample] = useState<string | null>(null);
+  
 
   const items: MenuProps["items"] = useMemo(
     () =>
@@ -38,7 +39,7 @@ const SampleDropdown = React.memo(function SampleDropdown({
         try {
           await loadSample(e.key);
           void message.info(`Loaded ${e.key} sample`);
-          setSelectedSample(e.key);
+
         } catch (error) {
           void message.error("Failed to load sample");
         } finally {
@@ -55,11 +56,11 @@ const SampleDropdown = React.memo(function SampleDropdown({
       <Dropdown menu={{ items, onClick: (e) => void handleMenuClick(e) }} trigger={["click"]}>
         <div className="samples-element">
           <Button aria-label="Load sample dropdown">
-            {selectedSample ? selectedSample : "Load Sample"} <DownOutlined />
+            {sampleName || "Load Sample"} <DownOutlined />
           </Button>
         </div>
       </Dropdown>
     </Space>
   );
-})
+}
 export default SampleDropdown;

--- a/src/components/SampleDropdown.tsx
+++ b/src/components/SampleDropdown.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Button, Dropdown, Space, message, MenuProps } from "antd";
 import { DownOutlined } from "@ant-design/icons";
 import { useCallback, useMemo, useState } from "react";
@@ -5,7 +6,7 @@ import useAppStore from "../store/store";
 import { shallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
-function SampleDropdown({
+const SampleDropdown = React.memo(function SampleDropdown({
   setLoading,
 }: {
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
@@ -60,6 +61,5 @@ function SampleDropdown({
       </Dropdown>
     </Space>
   );
-}
-
+})
 export default SampleDropdown;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -89,7 +89,9 @@ const useAppStore = create<AppState>()(
         const compressedData = params.get("data");
         if (compressedData) {
           await get().loadFromLink(compressedData);
-        } 
+        } else {
+          await get().loadSample(playground.NAME);
+        }
       },
       loadSample: async (name: string) => {
         const sample = SAMPLES.find((s) => s.NAME === name);


### PR DESCRIPTION
Optimize "Load Sample" Dropdown to Prevent Unnecessary Re-renders  

### Closes #330

### Summary  
This PR optimizes the "Load Sample" dropdown functionality to ensure that only the relevant components update instead of causing a full re-render of the body section. This improves performance, reduces unnecessary API calls, and prevents UI flickering.  

### Changes  
- Refactored state management to prevent full re-renders.  
-Used debounced validation to prevent excessive re-renders
- Ensured that selecting a sample only updates the editor/preview without reloading the entire UI.  



### Screenshots or Video  
(Attach any relevant screenshots or a video demonstrating the optimized behavior.)  
Before

https://github.com/user-attachments/assets/7b6f4513-1a82-4d3a-8b46-2b4432933dcb

After


https://github.com/user-attachments/assets/403c1227-a7a8-4841-8505-0a5784298b28


### Related Issues  
- Closes #330

### Author Checklist  
- [ ] Signed off commits using `--signoff`.  
- [ ] Added unit tests for the changes.  
- [ ] Commit messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format).  
- [ ] Updated relevant documentation if necessary.  
