### PR TITLE
fix(footer): open footer links in new tab for better UX

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -96,6 +96,8 @@ const CustomFooter: React.FC = () => {
                       <Link
                         href={link.href}
                         key={link.title}
+                        target="_blank"
+                        rel="noopener noreferrer"
                         style={{ color: "white", fontSize: "15px" }}
                       >
                         {link.title}


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #352 
<!--- Provide an overall summary of the pull request -->
This PR ensures that all external links in the website footer under(About, Community, Project sections) open in a new tab to improve user experience and avoid users unintentionally navigating away from the playground.
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added `target="_blank"` and `rel="noopener noreferrer"` to all external links in the footer.
- Verified proper navigation and tab opening behavior.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Make sure to verify that all links are external and not intended to be internal navigation.
- This change affects only the footer component.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #352 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
