### PR TITLE
theme toggle not affecting buttons

### DIFF
--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -4,10 +4,11 @@ import { Spin } from "antd";
 import useAppStore from "./store/store";
 import FullScreenModal from "./components/FullScreenModal";
 
-function AgreementHtml({ loading, isModal }: { loading: boolean; isModal?: boolean }) {
+function AgreementHtml({ isModal }: { isModal?: boolean; loading?: boolean }) {
   const agreementHtml = useAppStore((state) => state.agreementHtml);
   const backgroundColor = useAppStore((state) => state.backgroundColor);
   const textColor = useAppStore((state) => state.textColor);
+  const isLoading = useAppStore((state) => state.isLoading);
 
   return (
     <div
@@ -38,9 +39,9 @@ function AgreementHtml({ loading, isModal }: { loading: boolean; isModal?: boole
       <p style={{ textAlign: "center", color: textColor }}>
         The result of merging the JSON data with the template.
       </p>
-      {loading ? (
-        <div style={{ flex: 1, display: "flex", justifyContent: "center", alignItems: "center" }}>
-          <Spin indicator={<LoadingOutlined style={{ fontSize: 42, color: "#19c6c7" }} spin />} />
+      {isLoading ? (
+        <div style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', position: 'relative' }}>
+          <Spin indicator={<LoadingOutlined style={{ fontSize: 42, color: '#19c6c7' }} spin />} />
         </div>
       ) : (
         <div

--- a/src/components/SampleDropdown.tsx
+++ b/src/components/SampleDropdown.tsx
@@ -1,26 +1,27 @@
 import React from "react";
 import { Button, Dropdown, Space, message, MenuProps } from "antd";
 import { DownOutlined } from "@ant-design/icons";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import useAppStore from "../store/store";
 import { shallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
-const SampleDropdown = React.memo(function SampleDropdown({
+const SampleDropdown = function SampleDropdown({
   setLoading,
 }: {
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }): JSX.Element {
-  const { samples, loadSample } = useStoreWithEqualityFn(
+  const { samples, loadSample, sampleName } = useStoreWithEqualityFn(
     useAppStore,
     (state) => ({
       samples: state.samples,
       loadSample: state.loadSample as (key: string) => Promise<void>,
+      sampleName: state.sampleName
     }),
     shallow
   );
 
-  const [selectedSample, setSelectedSample] = useState<string | null>(null);
+  
 
   const items: MenuProps["items"] = useMemo(
     () =>
@@ -38,7 +39,7 @@ const SampleDropdown = React.memo(function SampleDropdown({
         try {
           await loadSample(e.key);
           void message.info(`Loaded ${e.key} sample`);
-          setSelectedSample(e.key);
+
         } catch (error) {
           void message.error("Failed to load sample");
         } finally {
@@ -55,11 +56,11 @@ const SampleDropdown = React.memo(function SampleDropdown({
       <Dropdown menu={{ items, onClick: (e) => void handleMenuClick(e) }} trigger={["click"]}>
         <div className="samples-element">
           <Button aria-label="Load sample dropdown">
-            {selectedSample ? selectedSample : "Load Sample"} <DownOutlined />
+            {sampleName || "Load Sample"} <DownOutlined />
           </Button>
         </div>
       </Dropdown>
     </Space>
   );
-})
+}
 export default SampleDropdown;

--- a/src/components/SampleDropdown.tsx
+++ b/src/components/SampleDropdown.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Button, Dropdown, Space, message, MenuProps } from "antd";
 import { DownOutlined } from "@ant-design/icons";
 import { useCallback, useMemo, useState } from "react";
@@ -5,7 +6,7 @@ import useAppStore from "../store/store";
 import { shallow } from "zustand/shallow";
 import { useStoreWithEqualityFn } from "zustand/traditional";
 
-function SampleDropdown({
+const SampleDropdown = React.memo(function SampleDropdown({
   setLoading,
 }: {
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
@@ -60,6 +61,5 @@ function SampleDropdown({
       </Dropdown>
     </Space>
   );
-}
-
+})
 export default SampleDropdown;

--- a/src/components/SampleDropdown.tsx
+++ b/src/components/SampleDropdown.tsx
@@ -11,12 +11,13 @@ const SampleDropdown = function SampleDropdown({
 }: {
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }): JSX.Element {
-  const { samples, loadSample, sampleName } = useStoreWithEqualityFn(
+  const { samples, loadSample, sampleName, backgroundColor } = useStoreWithEqualityFn(
     useAppStore,
     (state) => ({
       samples: state.samples,
       loadSample: state.loadSample as (key: string) => Promise<void>,
-      sampleName: state.sampleName
+      sampleName: state.sampleName,
+      backgroundColor: state.backgroundColor
     }),
     shallow
   );
@@ -28,6 +29,9 @@ const SampleDropdown = function SampleDropdown({
       samples?.map((s) => ({
         label: s.NAME,
         key: s.NAME,
+        style: backgroundColor === '#121212' ? {
+          color: '#fff'
+        } : undefined
       })) || [],
     [samples]
   );
@@ -53,9 +57,34 @@ const SampleDropdown = function SampleDropdown({
   
   return (
     <Space>
-      <Dropdown menu={{ items, onClick: (e) => void handleMenuClick(e) }} trigger={["click"]}>
+      <Dropdown 
+        menu={{ 
+          items, 
+          onClick: (e) => void handleMenuClick(e),
+          style: backgroundColor === '#121212' ? {
+            backgroundColor: '#1f1f1f',
+            color: '#fff',
+          } : undefined,
+        }} 
+        trigger={["click"]}
+        dropdownRender={menu => (
+          <div style={backgroundColor === '#121212' ? {
+            backgroundColor: '#1f1f1f',
+            color: '#fff',
+          } : undefined}>
+            {menu}
+          </div>
+        )}
+      >
         <div className="samples-element">
-          <Button aria-label="Load sample dropdown">
+          <Button 
+            aria-label="Load sample dropdown"
+            style={{
+              backgroundColor: backgroundColor === '#121212' ? '#1f1f1f' : undefined,
+              borderColor: backgroundColor === '#121212' ? '#434343' : undefined,
+              color: backgroundColor === '#121212' ? '#fff' : undefined
+            }}
+          >
             {sampleName || "Load Sample"} <DownOutlined />
           </Button>
         </div>

--- a/src/components/UseShare.tsx
+++ b/src/components/UseShare.tsx
@@ -2,10 +2,15 @@ import { useState } from "react";
 import { Button, message } from "antd";
 import { ShareAltOutlined } from "@ant-design/icons";
 import useAppStore from "../store/store";
+import { shallow } from "zustand/shallow";
 
 const UseShare = () => {
-  const generateShareableLink = useAppStore(
-    (state) => state.generateShareableLink
+  const { generateShareableLink, backgroundColor } = useAppStore(
+    (state) => ({
+      generateShareableLink: state.generateShareableLink,
+      backgroundColor: state.backgroundColor
+    }),
+    shallow
   );
   const [copied, setCopied] = useState(false);
 
@@ -24,7 +29,15 @@ const UseShare = () => {
 
   return (
     <div className="share-element">
-      <Button icon={<ShareAltOutlined />} onClick={handleCopy}>
+      <Button 
+        icon={<ShareAltOutlined />} 
+        onClick={handleCopy}
+        style={{
+          backgroundColor: backgroundColor === '#121212' ? '#1f1f1f' : undefined,
+          borderColor: backgroundColor === '#121212' ? '#434343' : undefined,
+          color: backgroundColor === '#121212' ? '#fff' : undefined
+        }}
+      >
         {copied ? "Copied!" : "Share"}
       </Button>
     </div>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -125,7 +125,7 @@ const useAppStore = create<AppState>()(
           );
           set(() => ({ agreementHtml: result, error: undefined }));
         } catch (error: any) {
-          set(() => ({ error: error instanceof Error ? error.message : 'Unknown error' }));
+          set(() => ({ error: formatError(error) }));
         } finally {
           set(() => ({ isLoading: false }));
         }
@@ -140,7 +140,7 @@ const useAppStore = create<AppState>()(
           const result = await rebuildDeBounce(template, modelCto, data);
           set(() => ({ agreementHtml: result, error: undefined })); 
         } catch (error: any) {
-          set(() => ({ error: error instanceof Error ? error.message : 'Unknown error' }));
+          set(() => ({ error: formatError(error) }));
         }
       },
       setEditorValue: (value: string) => {
@@ -156,7 +156,7 @@ const useAppStore = create<AppState>()(
           const result = await rebuildDeBounce(templateMarkdown, model, data);
           set(() => ({ agreementHtml: result, error: undefined })); 
         } catch (error: any) {
-          set(() => ({ error: error instanceof Error ? error.message : 'Unknown error' }));
+          set(() => ({ error: formatError(error) }));
         }
       },
       setEditorModelCto: (value: string) => {
@@ -175,7 +175,7 @@ const useAppStore = create<AppState>()(
           );
           set(() => ({ agreementHtml: result, error: undefined })); 
         } catch (error: any) {
-          set(() => ({ error: error instanceof Error ? error.message : 'Unknown error' }));
+          set(() => ({ error: formatError(error) }));
         }
       },
       setEditorAgreementData: (value: string) => {
@@ -235,3 +235,15 @@ const useAppStore = create<AppState>()(
 
 
 export default useAppStore;
+
+function formatError(error: any): string {
+  console.error(error);
+  if (typeof error === "string") return error;
+  if (Array.isArray(error)) return error.map((e) => formatError(e)).join("\n");
+  if (error.code) {
+    const sub = error.errors ? formatError(error.errors) : "";
+    const msg = error.renderedMessage || "";
+    return `Error: ${error.code} ${sub} ${msg}`;
+  }
+  return error.toString();
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -89,7 +89,9 @@ const useAppStore = create<AppState>()(
         const compressedData = params.get("data");
         if (compressedData) {
           await get().loadFromLink(compressedData);
-        } 
+        } else {
+          await get().loadSample(playground.NAME);
+        }
       },
       loadSample: async (name: string) => {
         const sample = SAMPLES.find((s) => s.NAME === name);


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

<!--- Provide an overall summary of the pull request -->
This pull request fixes the issue where the "Load Sample" and "Share" buttons in the body section did not update their UI on dark/light mode toggle. These buttons now respond correctly to theme changes.

### Changes
<!--- More detailed and granular description of changes -->
- Applied `dark`  theme classes to Load Sample and Share buttons
- Refactored button styling logic to support theme responsiveness

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Before
![Screenshot (276)](https://github.com/user-attachments/assets/75ca55fa-8ab6-4086-b92a-a0aedaa3ee4a)

### After
![Screenshot (275)](https://github.com/user-attachments/assets/4deed2db-80e3-4635-8996-7935de4ea06a)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:theme-toggle-button-fix`
