### PR TITLE
Add title attribute to sidebar navigation items

### DIFF
--- a/src/components/PlaygroundSidebar.tsx
+++ b/src/components/PlaygroundSidebar.tsx
@@ -158,6 +158,7 @@ const PlaygroundSidebar = () => {
             key={title}
             role="button"
             aria-label={title}
+            title={title}
             tabIndex={0}
             onClick={onClick}
             className={`group playground-sidebar-nav-item ${
@@ -182,6 +183,7 @@ const PlaygroundSidebar = () => {
             key={title}
             role="button"
             aria-label={title}
+            title={title}
             tabIndex={0}
             onClick={onClick}
             className={`group playground-sidebar-nav-bottom-item tour-${title.toLowerCase().replace(' ', '-')}`}


### PR DESCRIPTION
So, This PR shows the title of the icons when hovered by the cursor. 

# Problem
Earlier, It was difficult to understand what's the meaning of a particular icon in the side navbar. This reduced the user experience. 

# How I have solved this problem
Now, on hovering the icons it shows the title of that icon which makes it easier for the user to navigate. 

file changed: `PlaygroundSidebar.tsx`

# Video sample

https://github.com/user-attachments/assets/52eecb80-4e24-44ee-a4e2-e7386e352e15


