### PR TITLE
feat(ui): add copy to clipboard button to json panel

### DIFF
--- a/src/pages/MainContainer.tsx
+++ b/src/pages/MainContainer.tsx
@@ -9,7 +9,8 @@ import SampleDropdown from "../components/SampleDropdown";
 import { useState, useRef } from "react";
 import "../styles/pages/MainContainer.css";
 import html2pdf from "html2pdf.js";
-import { Button } from "antd";
+import { Button, message, Tooltip } from "antd";
+import { CopyOutlined } from "@ant-design/icons";
 
 const MainContainer = () => {
   const agreementHtml = useAppStore((state) => state.agreementHtml);
@@ -17,6 +18,12 @@ const MainContainer = () => {
   const [isDownloading, setIsDownloading] = useState(false);
   const backgroundColor = useAppStore((state) => state.backgroundColor);
   const textColor = useAppStore((state) => state.textColor);
+  const editorAgreementData = useAppStore((state) => state.editorAgreementData);
+
+  const handleCopyJson = () => {
+    navigator.clipboard.writeText(editorAgreementData);
+    message.success("JSON copied to clipboard!");
+  };
 
   const handleDownloadPdf = async () => {
     const element = downloadRef.current;
@@ -178,6 +185,19 @@ const MainContainer = () => {
                             {isDataCollapsed ? '▶' : '▼'}
                           </button>
                           <span>JSON Data</span>
+                          <Tooltip title="Copy JSON">
+                            <Button
+                              type="text"
+                              icon={<CopyOutlined />}
+                              size="small"
+                              onClick={handleCopyJson}
+                              style={{ 
+                                color: textColor, 
+                                marginLeft: '8px',
+                                background: 'transparent'
+                              }}
+                            />
+                          </Tooltip>
                         </div>
                       </div>
                       {!isDataCollapsed && (


### PR DESCRIPTION
# Closes #452
This PR adds a "Copy to Clipboard" button to the header of the "JSON Data" panel, allowing users to instantly copy the generated JSON agreement data without manually selecting the text.

### Changes
- Imported `CopyOutlined` icon from `@ant-design/icons` and `message` component from `antd` in `MainContainer.tsx`.
- Added `handleCopyJson` function that writes `editorAgreementData` to the clipboard and triggers a success toast.
- Inserted a `Tooltip`-wrapped copy button next to the "JSON Data" label in the panel header.

### Flags
- None. This is a purely frontend UI enhancement with no breaking changes.

### Screenshots or Video
<img width="872" height="271" alt="Screenshot 2025-12-23 235944" src="https://github.com/user-attachments/assets/be9424eb-dcec-4c92-a8b4-eb9ac5ef6011" />

### Related Issues
- Issue #452

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests (UI change only, manual verification performed).
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
