### PR TITLE
feat: add provider-aware model dropdown for AI Assistant 

### DIFF
--- a/.github/DCO-REMEDIATION.txt
+++ b/.github/DCO-REMEDIATION.txt
@@ -1,7 +1,0 @@
-Vaibhav <95979783+LaveUI@users.noreply.github.com>
-
-DCO Remediation Commit for Vaibhav <95979783+LaveUI@users.noreply.github.com>
-
-I, Vaibhav <95979783+LaveUI@users.noreply.github.com>, hereby add my Signed-off-by to this commit: be4016b9c967946b6399fcc201eac4d1c66957bc
-
-Signed-off-by: Vaibhav <95979783+LaveUI@users.noreply.github.com>

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -4,32 +4,35 @@ on:
   push:
     branches: 
       - main
+      
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
 
 jobs:
 
   publish:
     name: Deploy playground
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    environment: production
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: NPM Install
         if: github.ref == 'refs/heads/main'
-        run: npm install
+        run: npm ci
 
       - name: NPM Build
         run: SERVER_ROOT=https://playground.accordproject.org && NODE_OPTIONS=--max_old_space_size=8192 npm run build
@@ -40,16 +43,25 @@ jobs:
         run: |
             echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
 
-      - name: Deploy to S3
-        uses: jakejarvis/s3-sync-action@master
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          SOURCE_DIR: 'dist'
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Invalidate Cloudfront
-        uses: chetan/invalidate-cloudfront-action@master
+      - name: Deploy to S3
+        run: |
+          aws s3 sync dist s3://${{ secrets.AWS_S3_BUCKET }} \
+            --acl public-read \
+            --follow-symlinks \
+            --delete
         env:
-          DISTRIBUTION: ${{secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID}}
-          PATHS: '/*'
-          AWS_REGION: ${{secrets.AWS_REGION}}
+          AWS_REGION: 'us-east-1'
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"
+        env:
+          AWS_REGION: 'us-east-1'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,46 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: e2e-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,10 @@ on:
     branches: 
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build playground
@@ -12,19 +16,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: NPM Install
-        run: npm install
+        run: npm ci
 
       - name: NPM Build
         run: SERVER_ROOT=https://playground.accordproject.org && NODE_OPTIONS=--max_old_space_size=8192 npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     branches: 
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build playground
@@ -15,19 +19,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: NPM Install
-        run: npm install
+        run: npm ci
 
       - name: Unit Tests
         run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/DCO-REMEDIATION-Vaibhav.txt
+++ b/DCO-REMEDIATION-Vaibhav.txt
@@ -1,7 +1,0 @@
-Vaibhav <95979783+LaveUI@users.noreply.github.com>
-
-DCO Remediation Commit for Vaibhav <95979783+LaveUI@users.noreply.github.com>
-
-I, Vaibhav <95979783+LaveUI@users.noreply.github.com>, hereby add my Signed-off-by to this commit: 6e459f913e3f7c55c638614a444e0dbf466ed5b1
-
-Signed-off-by: Vaibhav <95979783+LaveUI@users.noreply.github.com>

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('App Loading', () => {
+  test('should load the app and display main components', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for loading to complete
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // Navbar should be visible with logo
+    await expect(page.getByRole('img', { name: 'Template Playground' })).toBeVisible();
+
+    // Sidebar should be visible with navigation buttons
+    await expect(page.getByRole('button', { name: 'Editor' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Preview' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Problems' })).toBeVisible();
+  });
+
+  test('should display editor panels', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // Check for editor panel headers
+    await expect(page.getByText('Concerto Model')).toBeVisible();
+    await expect(page.getByText('TemplateMark')).toBeVisible();
+    await expect(page.getByText('JSON Data')).toBeVisible();
+  });
+
+  test('should display Preview panel with content', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // Preview header should be visible
+    await expect(page.getByText('Preview').first()).toBeVisible();
+
+    // Download PDF button should be present
+    await expect(page.getByRole('button', { name: 'Download PDF' })).toBeVisible();
+
+    // Preview content area should have rendered HTML
+    const previewContent = page.locator('.main-container-agreement');
+    await expect(previewContent).toBeVisible();
+  });
+});
+
+test.describe('Dark Mode', () => {
+  test('should toggle dark mode', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // Get initial theme
+    const initialTheme = await page.evaluate(() => 
+      document.documentElement.getAttribute('data-theme')
+    );
+
+    // Find the dark mode toggle - assert it exists
+    const darkModeToggle = page.locator('[data-testid="toggle-dark-mode"]');
+    await expect(darkModeToggle, 'Dark mode toggle should be visible').toBeVisible();
+
+    // Click the toggle
+    await darkModeToggle.click();
+
+    // Theme should change
+    const newTheme = await page.evaluate(() => 
+      document.documentElement.getAttribute('data-theme')
+    );
+    expect(newTheme).not.toBe(initialTheme);
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test('should navigate to Learn page', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // Find and click the Learn button
+    const learnButton = page.locator('.learnNow-button');
+    await expect(learnButton).toBeVisible();
+    await learnButton.click();
+
+    // Should navigate to learn page
+    await expect(page).toHaveURL(/\/learn\/intro/);
+
+    // Learn page content should be visible
+    await expect(page.locator('body')).toContainText(/learn|intro|template/i);
+  });
+
+  test('should navigate back to playground from Learn page', async ({ page }) => {
+    await page.goto('/learn/intro');
+
+    // Wait for any loading to complete
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // Click the logo/home link to go back
+    const homeLink = page.getByRole('link', { name: 'Template Playground' }).first();
+    await expect(homeLink).toBeVisible();
+    await homeLink.click();
+
+    // Should be back at the playground
+    await expect(page).toHaveURL('/');
+  });
+
+  test('should have Help dropdown menu', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // Find Help button (visible on desktop)
+    const helpButton = page.getByRole('button', { name: /Help/i });
+    
+    // Skip test if Help button not visible (mobile view)
+    if (await helpButton.isVisible()) {
+      await helpButton.click();
+
+      // Dropdown should appear with menu items
+      await expect(page.getByText('About')).toBeVisible();
+      await expect(page.getByText('Community')).toBeVisible();
+      await expect(page.getByRole('link', { name: /Documentation/i })).toBeVisible();
+    }
+  });
+
+  test('should have external links in navbar', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // GitHub link should be present
+    const githubLink = page.getByRole('link', { name: /Github/i });
+    await expect(githubLink).toBeVisible();
+    await expect(githubLink).toHaveAttribute('href', 'https://github.com/accordproject/template-playground');
+
+    // Discord link should be present
+    const discordLink = page.getByRole('link', { name: /Discord/i });
+    await expect(discordLink).toBeVisible();
+    await expect(discordLink).toHaveAttribute('href', 'https://discord.com/invite/Zm99SKhhtA');
+  });
+});

--- a/e2e/share.spec.ts
+++ b/e2e/share.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Share Functionality', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+  });
+
+  test('should have Share button in sidebar', async ({ page }) => {
+    const shareButton = page.getByRole('button', { name: 'Share' });
+    await expect(shareButton).toBeVisible();
+  });
+
+  test('should copy shareable link to clipboard on Share click', async ({ page, context }) => {
+    // Grant clipboard permissions
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const shareButton = page.getByRole('button', { name: 'Share' });
+    await shareButton.click();
+
+    // Should show success message
+    await expect(page.getByText('Link copied to clipboard')).toBeVisible({ timeout: 5000 });
+
+    // Verify clipboard contains the link with data parameter
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardText).toContain('data=');
+  });
+
+  test('should load template from shared URL', async ({ page }) => {
+    // First, get a shareable link by clicking share
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const shareButton = page.getByRole('button', { name: 'Share' });
+    await shareButton.click();
+
+    // Wait for clipboard to be populated
+    await expect(page.getByText('Link copied to clipboard')).toBeVisible({ timeout: 5000 });
+
+    // Get the shareable link from clipboard
+    const shareableLink = await page.evaluate(() => navigator.clipboard.readText());
+    
+    // Validate that we got a non-empty string
+    expect(shareableLink, 'Shareable link should be a non-empty string').toBeTruthy();
+    expect(typeof shareableLink, 'Shareable link should be a string').toBe('string');
+
+    // Parse URL with validation
+    let url: URL;
+    try {
+      url = new URL(shareableLink);
+    } catch (error) {
+      throw new Error(`Failed to parse shareable link as URL: "${shareableLink}". Error: ${error}`);
+    }
+
+    // The app uses hash-based routing (#data=...) not query params (?data=...)
+    // Extract data from hash fragment
+    const hashParams = new URLSearchParams(url.hash.slice(1)); // Remove leading #
+    const dataParam = hashParams.get('data');
+    expect(
+      dataParam,
+      `URL should contain a "data" parameter in hash. Received URL: "${shareableLink}"`
+    ).toBeTruthy();
+
+    // Navigate to the shareable link using the hash
+    await page.goto(`/#data=${dataParam}`);
+
+    // Wait for app to load
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+
+    // Verify the app loaded successfully with content
+    await expect(page.locator('.main-container-agreement')).toBeVisible();
+  });
+
+  test('should have Start Tour button', async ({ page }) => {
+    const tourButton = page.getByRole('button', { name: 'Start Tour' });
+    await expect(tourButton).toBeVisible();
+  });
+
+  test('should have Settings button', async ({ page }) => {
+    const settingsButton = page.getByRole('button', { name: 'Settings' });
+    await expect(settingsButton).toBeVisible();
+  });
+});

--- a/e2e/template-workflow.spec.ts
+++ b/e2e/template-workflow.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Template Workflow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.app-spinner-container')).toBeHidden({ timeout: 30000 });
+  });
+
+  test('should have sample dropdown and change templates', async ({ page }) => {
+    // Find the sample dropdown button
+    const dropdown = page.getByRole('button', { name: 'Load sample dropdown' });
+    await expect(dropdown).toBeVisible();
+
+    // Click to open dropdown
+    await dropdown.click();
+
+    // Wait for dropdown options to appear
+    const helloWorldOption = page.getByText('Hello World', { exact: true });
+    await expect(helloWorldOption).toBeVisible({ timeout: 5000 });
+
+    // Select Hello World sample
+    await helloWorldOption.click();
+
+    // Verify the template content changed - should contain Hello World related content
+    await expect(page.locator('.main-container-agreement')).toContainText(/Hello|hello/i, {
+      timeout: 10000,
+    });
+  });
+
+  test('should collapse and expand editor panels', async ({ page }) => {
+    // Find the Concerto Model collapse button
+    const modelCollapseBtn = page.locator('button[title="Collapse"]').first();
+    await expect(modelCollapseBtn).toBeVisible();
+
+    // Click to collapse
+    await modelCollapseBtn.click();
+
+    // Button should now say Expand
+    await expect(page.locator('button[title="Expand"]').first()).toBeVisible();
+  });
+
+  test('should toggle Editor panel visibility', async ({ page }) => {
+    // Find Editor toggle button in sidebar
+    const editorToggle = page.getByRole('button', { name: 'Editor' });
+    await expect(editorToggle).toBeVisible();
+
+    // Initially editors should be visible
+    await expect(page.getByText('Concerto Model')).toBeVisible();
+
+    // Toggle off
+    await editorToggle.click();
+
+    // Editors should be hidden
+    await expect(page.getByText('Concerto Model')).toBeHidden();
+
+    // Toggle back on
+    await editorToggle.click();
+
+    // Editors should be visible again
+    await expect(page.getByText('Concerto Model')).toBeVisible();
+  });
+
+  test('should toggle Preview panel visibility', async ({ page }) => {
+    // Find Preview toggle button in sidebar
+    const previewToggle = page.getByRole('button', { name: 'Preview' });
+    await expect(previewToggle).toBeVisible();
+
+    // Initially preview should be visible
+    const previewPanel = page.locator('.tour-preview-panel');
+    await expect(previewPanel).toBeVisible();
+
+    // Ensure at least one editor panel is visible before hiding preview
+    // (app forbids hiding the last visible panel)
+    const editorToggle = page.getByRole('button', { name: 'Editor' });
+    const concertoModelHeader = page.getByText('Concerto Model');
+    
+    // If editors are not visible, click to show them first
+    if (!(await concertoModelHeader.isVisible())) {
+      await editorToggle.click();
+      await expect(concertoModelHeader).toBeVisible();
+    }
+
+    // Now toggle preview off
+    await previewToggle.click();
+
+    // Preview should be hidden
+    await expect(previewPanel).toBeHidden();
+
+    // Toggle back on
+    await previewToggle.click();
+
+    // Preview should be visible again
+    await expect(previewPanel).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,9 @@
         "antd": "^5.7.2",
         "core-js": "^3.37.1",
         "highlight.js": "^11.10.0",
-        "html2canvas": "^1.4.1",
         "html2pdf.js": "^0.12.1",
         "immer": "^10.1.1",
         "jest-canvas-mock": "^2.5.2",
-        "jspdf": "^3.0.4",
         "lz-string": "^1.5.0",
         "monaco-editor": "^0.50.0",
         "node-stdlib-browser": "^1.2.0",
@@ -57,6 +55,7 @@
         "@babel/core": "^7.24.7",
         "@babel/preset-env": "^7.24.7",
         "@babel/preset-react": "^7.24.7",
+        "@playwright/test": "^1.57.0",
         "@rollup/plugin-commonjs": "^25.0.2",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@tailwindcss/typography": "^0.5.16",
@@ -4388,6 +4387,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rc-component/color-picker": {
@@ -15018,12 +15033,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -17598,9 +17613,10 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "peer": true,
       "engines": {
         "node": ">= 6.13.0"
@@ -18529,6 +18545,53 @@
         "confbox": "^0.1.7",
         "mlly": "^1.7.0",
         "pathe": "^1.1.2"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "npm run test:unit",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@accordproject/concerto-core": "^3.11.1",
@@ -63,6 +65,7 @@
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
     "@babel/preset-react": "^7.24.7",
+    "@playwright/test": "^1.57.0",
     "@rollup/plugin-commonjs": "^25.0.2",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@tailwindcss/typography": "^0.5.16",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  // Run tests serially in CI for stability, parallel locally for speed
+  fullyParallel: !process.env.CI,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    // Set localStorage to prevent shepherd tour from appearing
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: 'http://localhost:5173',
+          localStorage: [
+            {
+              name: 'hasVisited',
+              value: 'true',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,13 @@ const App = () => {
     const initializeApp = async () => {
       try {
         setLoading(true);
-        const compressedData = searchParams.get("data");
+        // Prioritize hash for new links, fallback to searchParams for old links
+        let compressedData: string | null = null;
+        if (window.location.hash.startsWith("#data=")) {
+          compressedData = window.location.hash.substring(6);
+        } else {
+          compressedData = searchParams.get("data");
+        }
         if (compressedData) {
           await loadFromLink(compressedData);
           if (window.location.pathname !== "/") {
@@ -103,7 +109,7 @@ const App = () => {
     <AntdApp>
       <Layout style={{ height: "100vh" }}>
         <Navbar />
-        <Layout className="app-layout" style={{ backgroundColor, minHeight: '100vh' }}>
+        <Layout className="app-layout" style={{ backgroundColor }}>
           <Routes>
             <Route
               path="/"

--- a/src/ai-assistant/llmProviders.ts
+++ b/src/ai-assistant/llmProviders.ts
@@ -84,6 +84,13 @@ export class OpenRouterProvider extends OpenAICompatibleProvider {
   }
 }
 
+export class OllamaProvider extends OpenAICompatibleProvider {
+  constructor(config: AIConfig) {
+    const modifiedConfig = { ...config, apiKey: config.apiKey || 'ollama' };
+    super(modifiedConfig, 'http://localhost:11434/v1');
+  }
+}
+
 export class AnthropicProvider extends LLMProvider {
   async streamChat(
     messages: Message[],
@@ -245,6 +252,8 @@ export function getLLMProvider(config: AIConfig): LLMProvider {
       return new MistralProvider(config);
     case 'openrouter':
       return new OpenRouterProvider(config);
+    case 'ollama':  
+      return new OllamaProvider(config);
     case 'openai-compatible':
       if (!config.customEndpoint) {
         throw new Error('Custom API endpoint is required for OpenAI Compatible API');

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -165,7 +165,7 @@ export const AIChatPanel = () => {
         <div className="text-sm prose prose-sm break-all max-w-none" style={{ color: textColor }}>
           <ReactMarkdown
             components={{
-              code: ({ children, className }) => <code className={`${theme.inlineCode} p-1 rounded-md before:content-[''] after:content-[''] ${className}`}>{children}</code>,
+              code: ({ children, className }) => <code className={`${theme.inlineCode} p-1 rounded-md before:content-[''] after:content-[''] ${className || ''}`}>{children}</code>,
           }}>
             {content}
           </ReactMarkdown>
@@ -233,7 +233,7 @@ export const AIChatPanel = () => {
   }, [chatState.messages, chatState.isLoading]);
 
   return (
-    <div className="twp pl-4 pr-4 -mr-1 flex flex-col border rounded-md h-[calc(100vh-150px)] h-full">
+    <div className="twp pl-4 pr-4 -mr-1 flex flex-col border rounded-md h-full">
       <div className={theme.header}>
         <h2 className="text-lg font-bold" style={{ color: textColor }}>AI Assistant</h2>
         <div className="flex items-center gap-2">

--- a/src/components/FullScreenModal.tsx
+++ b/src/components/FullScreenModal.tsx
@@ -20,9 +20,13 @@ const FullScreenModal: React.FC = () => {
         background-color: ${backgroundColor} !important;
         color: ${textColor} !important;
       }
-      .ant-modal-title{
+      .ant-modal-title {
         color: ${textColor} !important;
-        }
+      }
+      /* Fixes invisible close button in dark mode */
+      .ant-modal-close {
+        color: ${textColor} !important;
+      }
     `;
     document.head.appendChild(style);
     return () => {

--- a/src/components/LearningPathwaySidebar.tsx
+++ b/src/components/LearningPathwaySidebar.tsx
@@ -39,7 +39,7 @@ const LearningPathwaySidebar: React.FC<SidebarProps> = ({ steps }) => {
         </HelperIcon>
         <HelperText>
           Welcome to the Learning Pathway! Use the sidebar to follow the guide.
-          Open the {" "}
+          Open the
           <Link to="/" target="_blank" rel="noopener noreferrer">
             Template Playground
           </Link>{" "}

--- a/src/components/PlaygroundSidebar.tsx
+++ b/src/components/PlaygroundSidebar.tsx
@@ -5,7 +5,7 @@ import { FiTerminal, FiShare2, FiSettings } from "react-icons/fi";
 import { FaCirclePlay } from "react-icons/fa6";
 import { IoChatbubbleEllipsesOutline } from "react-icons/io5";
 import useAppStore from "../store/store";
-import { message } from "antd";
+import { message, Tooltip } from "antd";
 import FullScreenModal from "./FullScreenModal";
 import tour from "./Tour";
 import "../styles/components/PlaygroundSidebar.css";
@@ -154,11 +154,10 @@ const PlaygroundSidebar = () => {
     <aside className="playground-sidebar">
       <nav className="playground-sidebar-nav">
         {navTop.map(({ title, icon: Icon, component, onClick, active }) => (
+          <Tooltip key={title} title={title} placement="right">
           <div
-            key={title}
             role="button"
             aria-label={title}
-            title={title}
             tabIndex={0}
             onClick={onClick}
             className={`group playground-sidebar-nav-item ${
@@ -174,16 +173,16 @@ const PlaygroundSidebar = () => {
             ) : null}
             <span className="playground-sidebar-nav-item-title">{title}</span>
           </div>
+          </Tooltip>
         ))}
       </nav>
 
       <nav className="playground-sidebar-nav-bottom">
         {navBottom.map(({ title, icon: Icon, onClick }) => (
+          <Tooltip key={title} title={title} placement="right">
           <div
-            key={title}
             role="button"
             aria-label={title}
-            title={title}
             tabIndex={0}
             onClick={onClick}
             className={`group playground-sidebar-nav-bottom-item tour-${title.toLowerCase().replace(' ', '-')}`}
@@ -191,6 +190,7 @@ const PlaygroundSidebar = () => {
             <Icon size={22} />
             <span className="playground-sidebar-nav-item-title">{title}</span>
           </div>
+          </Tooltip>
         ))}
       </nav>
     </aside>

--- a/src/components/ToggleDarkMode.tsx
+++ b/src/components/ToggleDarkMode.tsx
@@ -19,7 +19,7 @@ const ToggleDarkMode: React.FC = () => {
   };
 
   return (
-    <ToggleDarkModeContainer>
+    <ToggleDarkModeContainer data-testid="toggle-dark-mode">
       <DarkModeToggle
         className="dark-mode-toggle"
         onChange={handleChange}

--- a/src/editors/JSONEditor.tsx
+++ b/src/editors/JSONEditor.tsx
@@ -11,9 +11,11 @@ const MonacoEditor = lazy(() =>
 export default function JSONEditor({
   value,
   onChange,
+  editorRef,
 }: {
   value: string;
   onChange?: (value: string | undefined) => void;
+  editorRef?: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>;
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("json");
   
@@ -58,6 +60,9 @@ export default function JSONEditor({
   };
 
   const handleEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    if (editorRef) {
+      editorRef.current = editor;
+    }
     editor.onDidChangeCursorSelection(() => {
       handleSelection(editor);
     });

--- a/src/editors/editorsContainer/AgreementData.tsx
+++ b/src/editors/editorsContainer/AgreementData.tsx
@@ -2,8 +2,9 @@ import JSONEditor from "../JSONEditor";
 import useAppStore from "../../store/store";
 import useUndoRedo from "../../components/useUndoRedo";
 import { updateEditorActivity } from "../../ai-assistant/activityTracker";
+import * as monaco from "monaco-editor";
 
-function AgreementData() {
+function AgreementData({ editorRef }: { editorRef?: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null> }) {
   const editorAgreementData = useAppStore((state) => state.editorAgreementData);
   const setEditorAgreementData = useAppStore((state) => state.setEditorAgreementData);
   const setData = useAppStore((state) => state.setData);
@@ -22,7 +23,7 @@ function AgreementData() {
   };
 
   return (
-    <JSONEditor value={value} onChange={handleChange} />
+    <JSONEditor value={value} onChange={handleChange} editorRef={editorRef} />
   );
 }
 

--- a/src/pages/MainContainer.tsx
+++ b/src/pages/MainContainer.tsx
@@ -10,10 +10,13 @@ import { useState, useRef } from "react";
 import "../styles/pages/MainContainer.css";
 import html2pdf from "html2pdf.js";
 import { Button } from "antd";
+import * as monaco from "monaco-editor";
+import { MdFormatAlignLeft, MdChevronRight, MdExpandMore } from "react-icons/md";
 
 const MainContainer = () => {
   const agreementHtml = useAppStore((state) => state.agreementHtml);
   const downloadRef = useRef<HTMLDivElement>(null);
+  const jsonEditorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const backgroundColor = useAppStore((state) => state.backgroundColor);
   const textColor = useAppStore((state) => state.textColor);
@@ -46,6 +49,12 @@ const MainContainer = () => {
     }
   }
 
+  const handleJsonFormat = () => {
+    if (jsonEditorRef.current) {
+      jsonEditorRef.current.getAction('editor.action.formatDocument')?.run();
+    }
+  };
+
   const {
     isAIChatOpen,
     isEditorsVisible,
@@ -77,7 +86,7 @@ const MainContainer = () => {
   const expandedCount = 3 - collapsedCount;
   const collapsedSize = 5;
   const expandedSize = expandedCount > 0 ? (100 - (collapsedCount * collapsedSize)) / expandedCount : 33;
-  
+
   // Create a key that changes when collapse state changes to force panel re-layout
   const panelKey = `${isModelCollapsed}-${isTemplateCollapsed}-${isDataCollapsed}`;
 
@@ -98,18 +107,19 @@ const MainContainer = () => {
                           <button
                             className="collapse-button"
                             onClick={toggleModelCollapse}
-                            style={{ 
-                              color: textColor, 
-                              background: 'transparent', 
-                              border: 'none', 
+                            style={{
+                              color: textColor,
+                              background: 'transparent',
+                              border: 'none',
                               cursor: 'pointer',
-                              fontSize: '16px',
-                              padding: '4px 8px',
-                              marginRight: '8px'
+                              display: 'flex',
+                              alignItems: 'center',
+                              padding: '4px',
+                              marginRight: '4px'
                             }}
                             title={isModelCollapsed ? "Expand" : "Collapse"}
                           >
-                            {isModelCollapsed ? '▶' : '▼'}
+                            {isModelCollapsed ? <MdChevronRight size={20} /> : <MdExpandMore size={20} />}
                           </button>
                           <span>Concerto Model</span>
                           <SampleDropdown setLoading={setLoading} />
@@ -131,18 +141,19 @@ const MainContainer = () => {
                           <button
                             className="collapse-button"
                             onClick={toggleTemplateCollapse}
-                            style={{ 
-                              color: textColor, 
-                              background: 'transparent', 
-                              border: 'none', 
+                            style={{
+                              color: textColor,
+                              background: 'transparent',
+                              border: 'none',
                               cursor: 'pointer',
-                              fontSize: '16px',
-                              padding: '4px 8px',
-                              marginRight: '8px'
+                              display: 'flex',
+                              alignItems: 'center',
+                              padding: '4px',
+                              marginRight: '4px'
                             }}
                             title={isTemplateCollapsed ? "Expand" : "Collapse"}
                           >
-                            {isTemplateCollapsed ? '▶' : '▼'}
+                            {isTemplateCollapsed ? <MdChevronRight size={20} /> : <MdExpandMore size={20} />}
                           </button>
                           <span>TemplateMark</span>
                         </div>
@@ -164,25 +175,33 @@ const MainContainer = () => {
                           <button
                             className="collapse-button"
                             onClick={toggleDataCollapse}
-                            style={{ 
-                              color: textColor, 
-                              background: 'transparent', 
-                              border: 'none', 
+                            style={{
+                              color: textColor,
+                              background: 'transparent',
+                              border: 'none',
                               cursor: 'pointer',
-                              fontSize: '16px',
-                              padding: '4px 8px',
-                              marginRight: '8px'
+                              display: 'flex',
+                              alignItems: 'center',
+                              padding: '4px',
+                              marginRight: '4px'
                             }}
                             title={isDataCollapsed ? "Expand" : "Collapse"}
                           >
-                            {isDataCollapsed ? '▶' : '▼'}
+                            {isDataCollapsed ? <MdChevronRight size={20} /> : <MdExpandMore size={20} />}
                           </button>
                           <span>JSON Data</span>
                         </div>
+                        <button
+                          onClick={handleJsonFormat}
+                          className="px-1 pt-1 border-gray-300 bg-white hover:bg-gray-200 rounded shadow-md"
+                          disabled={!jsonEditorRef.current || isDataCollapsed}
+                        >
+                          <MdFormatAlignLeft size={16} />
+                        </button>
                       </div>
                       {!isDataCollapsed && (
                         <div className="main-container-editor-content" style={{ backgroundColor }}>
-                          <AgreementData />
+                          <AgreementData editorRef={jsonEditorRef} />
                         </div>
                       )}
                     </div>
@@ -207,12 +226,12 @@ const MainContainer = () => {
               <div className="main-container-preview-panel tour-preview-panel" style={{ backgroundColor }}>
                 <div className={`main-container-preview-header ${backgroundColor === '#ffffff' ? 'main-container-preview-header-light' : 'main-container-preview-header-dark'}`}>
                   <span>Preview</span>
-                  <Button 
+                  <Button
                     onClick={handleDownloadPdf}
-                    loading={isDownloading} 
+                    loading={isDownloading}
                     style={{ marginLeft: "10px" }}
                   >
-                   Download PDF
+                    Download PDF
                   </Button>
                 </div>
                 <div className="main-container-preview-content" style={{ backgroundColor }}>

--- a/src/samples/employmentOffer.ts
+++ b/src/samples/employmentOffer.ts
@@ -1,0 +1,75 @@
+/**
+ * Employment Offer Letter sample
+ * This sample demonstrates how multiple Accord Project components
+ * work together in a real-world scenario.
+ */
+
+const MODEL = `namespace org.accordproject.employment@1.0.0
+
+/**
+ * Represents a monetary value with currency
+ */
+concept MonetaryAmount {
+  o Double doubleValue
+  o String currencyCode
+}
+
+/**
+ * Optional probation details
+ */
+concept Probation {
+  o Integer months
+}
+
+/**
+ * Main template model for the employment offer
+ */
+@template
+concept EmploymentOffer {
+  o String candidateName
+  o String companyName
+  o String roleTitle
+  o MonetaryAmount annualSalary
+  o DateTime startDate
+  o Probation probation optional
+}`;
+const TEMPLATE = `DATE: {{startDate as "DD MMMM YYYY"}}
+
+Dear {{candidateName}},
+
+We are pleased to offer you the position of **{{roleTitle}}** at **{{companyName}}**.
+
+Your employment with {{companyName}} will commence on {{startDate as "DD MMMM YYYY"}}.
+
+{{#clause annualSalary}}
+Your annual gross salary will be **{{doubleValue as "0,0"}} {{currencyCode}}**, payable in accordance with company policies.
+{{/clause}}
+
+{{#clause probation condition="return probation !== undefined"}}
+This offer includes a probation period of **{{months}} months**, during which your performance and suitability for the role will be evaluated.
+{{/clause}}
+
+We are excited about the opportunity to work with you and look forward to your contribution to the team.
+
+Sincerely,  
+**Human Resources**  
+{{companyName}}`;
+const DATA = {
+  "$class": "org.accordproject.employment@1.0.0.EmploymentOffer",
+  "candidateName": "Ishan Gupta",
+  "companyName": "Tech Innovators Inc.",
+  "roleTitle": "Junior AI Engineer",
+  "annualSalary": {
+    "$class": "org.accordproject.employment@1.0.0.MonetaryAmount",
+    "doubleValue": 85000,
+    "currencyCode": "USD"
+  },
+  "startDate": "2025-02-01T09:00:00.000Z",
+  "probation": {
+    "$class": "org.accordproject.employment@1.0.0.Probation",
+    "months": 3
+  }
+};
+const NAME = 'Employment Offer Letter ';
+
+export { NAME, MODEL, DATA, TEMPLATE };

--- a/src/samples/index.ts
+++ b/src/samples/index.ts
@@ -12,6 +12,7 @@ import * as invitation from "./invitation";
 import * as announcement from "./announcement";
 import * as blank from "./blank";
 import * as paymentReceipt from './paymentReceipt';
+import * as employmentOffer from "./employmentOffer";
 
 export type Sample = {
   NAME: string;
@@ -23,6 +24,7 @@ export type Sample = {
 export const SAMPLES: Array<Sample> = [
   playground,
   helloworld,
+  employmentOffer,
   formula,
   formulanow,
   join,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -108,10 +108,42 @@ const getInitialTheme = () => {
   return { backgroundColor: '#ffffff', textColor: '#121212' };
 };
 
+/* --- Helper to safely load panel state --- */
+const getInitialPanelState = () => {
+  const defaults = {
+    isEditorsVisible: true,
+    isPreviewVisible: true,
+    isProblemPanelVisible: false,
+    isAIChatOpen: false,
+  };
+  if (typeof window !== 'undefined') {
+    try {
+      const saved = localStorage.getItem('ui-panels');
+      if (saved) return { ...defaults, ...JSON.parse(saved) };
+    } catch (e) { /* ignore */ }
+  }
+  return defaults;
+};
+
+/* --- Helper to safely save panel state --- */
+const savePanelState = (state: Partial<AppState>) => {
+  if (typeof window !== 'undefined') {
+    const panels = {
+      isEditorsVisible: state.isEditorsVisible,
+      isPreviewVisible: state.isPreviewVisible,
+      isProblemPanelVisible: state.isProblemPanelVisible,
+      isAIChatOpen: state.isAIChatOpen,
+    };
+    localStorage.setItem('ui-panels', JSON.stringify(panels));
+  }
+};
+
 const useAppStore = create<AppState>()(
   immer(
     devtools((set, get) => {
       const initialTheme = getInitialTheme();
+      const initialPanels = getInitialPanelState(); // Load saved panels
+
       return {
         backgroundColor: initialTheme.backgroundColor,
         textColor: initialTheme.textColor,
@@ -124,7 +156,7 @@ const useAppStore = create<AppState>()(
       editorAgreementData: JSON.stringify(playground.DATA, null, 2),
       agreementHtml: "",
       isAIConfigOpen: false,
-      isAIChatOpen: false,
+      isAIChatOpen: initialPanels.isAIChatOpen, 
       error: undefined,
       samples: SAMPLES,
       chatState: {
@@ -134,9 +166,9 @@ const useAppStore = create<AppState>()(
       },
       aiConfig: null,
       chatAbortController: null,
-      isEditorsVisible: true,
-      isPreviewVisible: true,
-      isProblemPanelVisible: false,
+      isEditorsVisible: initialPanels.isEditorsVisible, 
+      isPreviewVisible: initialPanels.isPreviewVisible, 
+      isProblemPanelVisible: initialPanels.isProblemPanelVisible, 
       isModelCollapsed: false,
       isTemplateCollapsed: false,
       isDataCollapsed: false,
@@ -149,6 +181,7 @@ const useAppStore = create<AppState>()(
           return;
         }
         set({ isEditorsVisible: value });
+        savePanelState({ ...get(), isEditorsVisible: value }); // Save change
       },
       setPreviewVisible: (value) => {
         const state = get();
@@ -156,8 +189,12 @@ const useAppStore = create<AppState>()(
           return;
         }
         set({ isPreviewVisible: value });
+        savePanelState({ ...get(), isPreviewVisible: value }); // Save change
       },
-      setProblemPanelVisible: (value) => set({ isProblemPanelVisible: value }),
+      setProblemPanelVisible: (value) => {
+        set({ isProblemPanelVisible: value });
+        savePanelState({ ...get(), isProblemPanelVisible: value }); // Save change
+      },
       init: async () => {
         const params = new URLSearchParams(window.location.search);
         const compressedData = params.get("data");
@@ -188,7 +225,7 @@ const useAppStore = create<AppState>()(
         const { templateMarkdown, modelCto, data } = get();
         try {
           const result = await rebuildDeBounce(templateMarkdown, modelCto, data);
-          set(() => ({ agreementHtml: result, error: undefined })); // Clear error on success
+          set(() => ({ agreementHtml: result, error: undefined })); 
         } catch (error: any) {
           set(() => ({ error: formatError(error), isProblemPanelVisible: true }));
         }
@@ -198,7 +235,7 @@ const useAppStore = create<AppState>()(
         const { modelCto, data } = get();
         try {
           const result = await rebuildDeBounce(template, modelCto, data);
-          set(() => ({ agreementHtml: result, error: undefined })); // Clear error on success
+          set(() => ({ agreementHtml: result, error: undefined })); 
         } catch (error: any) {
           set(() => ({ error: formatError(error), isProblemPanelVisible: true }));
         }
@@ -211,7 +248,7 @@ const useAppStore = create<AppState>()(
         const { templateMarkdown, data } = get();
         try {
           const result = await rebuildDeBounce(templateMarkdown, model, data);
-          set(() => ({ agreementHtml: result, error: undefined })); // Clear error on success
+          set(() => ({ agreementHtml: result, error: undefined })); 
         } catch (error: any) {
           set(() => ({ error: formatError(error), isProblemPanelVisible: true }));
         }
@@ -227,7 +264,7 @@ const useAppStore = create<AppState>()(
             get().modelCto,
             data
           );
-          set(() => ({ agreementHtml: result, error: undefined })); // Clear error on success
+          set(() => ({ agreementHtml: result, error: undefined })); 
         } catch (error: any) {
           set(() => ({ error: formatError(error), isProblemPanelVisible: true }));
         }
@@ -243,7 +280,7 @@ const useAppStore = create<AppState>()(
           data: state.data,
           agreementHtml: state.agreementHtml,
         });
-        return `${window.location.origin}?data=${compressedData}`;
+        return `${window.location.origin}/#data=${compressedData}`;
       },
       loadFromLink: async (compressedData: string) => {
         try {
@@ -276,7 +313,7 @@ const useAppStore = create<AppState>()(
             backgroundColor: isDark ? '#ffffff' : '#121212',
             textColor: isDark ? '#121212' : '#ffffff',
           };
-          
+           
           if (typeof window !== 'undefined') {
             const themeValue = isDark ? 'light' : 'dark';
             localStorage.setItem('theme', themeValue);
@@ -286,12 +323,15 @@ const useAppStore = create<AppState>()(
               // ignore
             }
           }
-          
+           
           return newTheme;
         });
       },
       setAIConfigOpen: (isOpen: boolean) => set(() => ({ isAIConfigOpen: isOpen })),
-      setAIChatOpen: (isOpen: boolean) => set(() => ({ isAIChatOpen: isOpen })),
+      setAIChatOpen: (isOpen: boolean) => {
+        set(() => ({ isAIChatOpen: isOpen }));
+        savePanelState({ ...get(), isAIChatOpen: isOpen }); // Save change
+      },
       setChatState: (state) => set({ chatState: state }),
       updateChatState: (partial) => set((state) => ({ 
         chatState: { ...state.chatState, ...partial } 
@@ -331,3 +371,4 @@ function formatError(error: any): string {
   }
   return error.toString();
 }
+

--- a/src/tests/components/PlaygroundSidebar.test.tsx
+++ b/src/tests/components/PlaygroundSidebar.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import PlaygroundSidebar from "../../components/PlaygroundSidebar";
+import { vi } from "vitest";
+
+// Mock the store
+vi.mock("../../store/store", () => ({
+    default: () => ({
+        isEditorsVisible: true,
+        isPreviewVisible: true,
+        isProblemPanelVisible: false,
+        isAIChatOpen: false,
+        setEditorsVisible: vi.fn(),
+        setPreviewVisible: vi.fn(),
+        setProblemPanelVisible: vi.fn(),
+        setAIChatOpen: vi.fn(),
+        generateShareableLink: vi.fn(() => "https://example.com"),
+    }),
+}));
+
+// Mock the Tour
+vi.mock("../../components/Tour", () => ({
+    default: { start: vi.fn() },
+}));
+
+// Mock FullScreenModal
+vi.mock("../../components/FullScreenModal", () => ({
+    default: () => <div data-testid="fullscreen-modal">FullScreen</div>,
+}));
+
+const renderSidebar = () => {
+    render(<PlaygroundSidebar />);
+};
+
+describe("PlaygroundSidebar", () => {
+    it("renders all top navigation items", () => {
+        renderSidebar();
+
+        expect(screen.getByRole("button", { name: /Editor/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Preview/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Problems/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /AI Assistant/i })).toBeInTheDocument();
+    });
+
+    it("renders all bottom navigation items", () => {
+        renderSidebar();
+
+        expect(screen.getByRole("button", { name: /Share/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Start Tour/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Settings/i })).toBeInTheDocument();
+    });
+
+    it("wraps navigation items with Tooltip component", async () => {
+        renderSidebar();
+        const editorButton = screen.getByRole("button", { name: /Editor/i });
+        expect(editorButton).toBeInTheDocument();
+    });
+
+    it("renders FullScreen modal component", () => {
+        renderSidebar();
+        expect(screen.getByTestId("fullscreen-modal")).toBeInTheDocument();
+    });
+});

--- a/src/tests/components/__snapshots__/Footer.test.tsx.snap
+++ b/src/tests/components/__snapshots__/Footer.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`Footer > matches the snapshot 1`] = `
           class="ant-typography css-dev-only-do-not-override-17a39f8"
           style="color: rgba(255, 255, 255, 0.85);"
         >
-          copyright © 2025 accord project • 
+          copyright © 2026 accord project • 
           <a
             class="ant-typography css-dev-only-do-not-override-17a39f8"
             href="https://accordproject.org/privacy"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig as defineViteConfig, mergeConfig } from "vite";
-import { defineConfig as defineVitestConfig } from "vitest/config";
+import { defineConfig as defineVitestConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import nodePolyfills from "vite-plugin-node-stdlib-browser";
 import { visualizer } from "rollup-plugin-visualizer";
@@ -22,6 +22,7 @@ const vitestConfig = defineVitestConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: "./src/utils/testing/setup.ts",
+    exclude: [...configDefaults.exclude, "**/e2e/**"],
   },
 });
 


### PR DESCRIPTION
### Summary

* Adds provider-aware Model selection dropdown
* Replaces manual model text input with `<select>` for providers with predefined models
* Falls back to text input for custom providers (e.g., `openai-compatible`)
* Clears Model field automatically on Provider change using `useEffect`
* Disables browser autocomplete with `autoComplete="off"`

### Technical Details

* Added `PROVIDER_MODEL_OPTIONS` map for suggested models per provider
* Uses conditional rendering for dropdown vs text input
* No unrelated logic or structure modified

### Verification

* Build runs successfully after changes
* No new lint warnings or errors introduced

### Video Sample

https://github.com/user-attachments/assets/d04f4b8d-6f48-4aa1-bcb4-bbba4359a6d2

Fixes #451 

