### PR TITLE
fix(store): format complex types (Duration, Period) as readable text

### DIFF
--- a/src/tests/components/__snapshots__/Footer.test.tsx.snap
+++ b/src/tests/components/__snapshots__/Footer.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`Footer > matches the snapshot 1`] = `
           class="ant-typography css-dev-only-do-not-override-17a39f8"
           style="color: rgba(255, 255, 255, 0.85);"
         >
-          copyright © 2025 accord project • 
+          copyright © 2026 accord project • 
           <a
             class="ant-typography css-dev-only-do-not-override-17a39f8"
             href="https://accordproject.org/privacy"


### PR DESCRIPTION
# Closes #14

Adds post-processing to convert JSON representations of complex Accord Project types to human-readable format in the preview.

### Summary
When using complex Accord Project types like `Duration` or `Period` in TemplateMark templates, they were rendering as raw JSON instead of human-readable text. This PR adds a [formatComplexTypes()](cci:1://file:///home/shubhraj/OpenSource/playground/src/store/store.ts:73:0-84:1) function that post-processes the generated HTML.

**Before:** `{"$class":"org.accordproject.time@0.3.0.Duration","amount":2,"unit":"days"}`

**After:** `2 days`

### Changes
- Added [formatComplexTypes()](cci:1://file:///home/shubhraj/OpenSource/playground/src/store/store.ts:73:0-84:1) function in [src/store/store.ts](cci:7://file:///home/shubhraj/OpenSource/playground/src/store/store.ts:0:0-0:0) to format Duration, Period, and MonetaryAmount types
- Uses JSON parsing to handle variable property order in JSON objects
- Modified [rebuild()](cci:1://file:///home/shubhraj/OpenSource/playground/src/store/store.ts:87:0-109:1) to apply formatting before returning HTML

### Flags
- This is a playground-side workaround; a proper upstream fix in `@accordproject/template-engine` is also proposed: https://github.com/accordproject/template-engine/pull/52
- Currently supports Duration, Period, and MonetaryAmount; more types can be added as needed

### Screenshots
<img width="1732" height="806" alt="Screenshot from 2026-01-01 14-01-04" src="https://github.com/user-attachments/assets/6e58a971-5379-41a8-9651-4d25110a23e7" />

### Related Issues
- Issue #14

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary (N/A)
- [x] Merging to `main` from `Shubh-Raj:shubh-raj/fix/complex-type-formatting`