### PR TITLE
ci: Add automatic PR labeling based on file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,69 @@
+# Label configuration for actions/labeler
+# See: https://github.com/actions/labeler
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+components:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/components/**'
+
+editors:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/editors/**'
+
+pages:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/pages/**'
+
+utils:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/utils/**'
+
+store:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/store/**'
+
+styles:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/styles/**'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/tests/**'
+
+ai-assistant:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/ai-assistant/**'
+
+assets:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'public/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'package-lock.json'
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '*.config.*'
+          - 'tsconfig.*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: Label PR based on file paths
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# closes #504 
Add GitHub Actions workflow to automatically label PRs based on which files are modified, improving PR triage and organization.

### Changes
- Add [.github/labeler.yml](cci:7://file:///home/shubhraj/OpenSource/playground/.github/labeler.yml:0:0-0:0) config file mapping file paths to labels
- Add [.github/workflows/labeler.yml](cci:7://file:///home/shubhraj/OpenSource/playground/.github/workflows/labeler.yml:0:0-0:0) workflow using `actions/labeler@v5`

### Labels Applied
| Label | Trigger Files |
|-------|---------------|
| `documentation` | `*.md` |
| `ci` | `.github/**` |
| `components` | `src/components/**` |
| `editors` | `src/editors/**` |
| `pages` | `src/pages/**` |
| `utils` | `src/utils/**` |
| `store` | `src/store/**` |
| `styles` | `src/styles/**` |
| `tests` | `src/tests/**` |
| `ai-assistant` | `src/ai-assistant/**` |
| `assets` | `public/**` |
| `dependencies` | [package.json](cci:7://file:///home/shubhraj/OpenSource/playground/package.json:0:0-0:0), [package-lock.json](cci:7://file:///home/shubhraj/OpenSource/playground/package-lock.json:0:0-0:0) |
| `config` | `*.config.*`, `tsconfig.*` |

### Flags
- Labels must be created in repository settings before workflow runs
- Workflow triggers on `opened`, `synchronize`, `reopened` PR events

### Screenshots or Video
N/A - CI automation, no UI changes

### Related Issues
N/A

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`