### PR TITLE
chore(ci): add concurrency control to workflows

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,10 @@ on:
     branches: 
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build playground

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     branches: 
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build playground


### PR DESCRIPTION
Closes #507 

This PR adds concurrency control to CI workflows to cancel in-progress runs when new commits are pushed to the same branch/PR.

### Changes
- Added concurrency control to [pr-check.yml](cci:7://file:///home/shubhraj/OpenSource/playground/.github/workflows/pr-check.yml:0:0-0:0)
- Added concurrency control to [test.yml](cci:7://file:///home/shubhraj/OpenSource/playground/.github/workflows/test.yml:0:0-0:0)
- Uses group key `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
  - Groups PR runs by PR number for cleaner handling
  - Falls back to branch ref for push events
- Enables `cancel-in-progress: true` to auto-cancel older runs

### Flags
- Reduces wasted CI minutes when multiple commits are pushed quickly
- Each PR/branch gets its own concurrency group (PRs don't cancel each other)
- Not applied to [build-and-publish.yml](cci:7://file:///home/shubhraj/OpenSource/playground/.github/workflows/build-and-publish.yml:0:0-0:0) (deploy workflow - should not be cancelled mid-deploy)

### Screenshots or Video
N/A - CI workflow only

### Related Issues
- None (proactive optimization)

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`