### PR TITLE
test: update Footer snapshot for 2026 copyright year

### DIFF
--- a/src/tests/components/__snapshots__/Footer.test.tsx.snap
+++ b/src/tests/components/__snapshots__/Footer.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`Footer > matches the snapshot 1`] = `
           class="ant-typography css-dev-only-do-not-override-17a39f8"
           style="color: rgba(255, 255, 255, 0.85);"
         >
-          copyright © 2025 accord project • 
+          copyright © 2026 accord project • 
           <a
             class="ant-typography css-dev-only-do-not-override-17a39f8"
             href="https://accordproject.org/privacy"


### PR DESCRIPTION
# Closes #497

Updates the Footer component snapshot test to reflect the copyright year change from 2025 to 2026.

### Changes
- Updated Footer snapshot to use copyright year 2026

### Flags
- None

### Screenshots or Video
N/A - Snapshot update only

### Related Issues
- Issue #497

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `Shubh-Raj:fix/update-footer-snapshot-2026`