### PR TITLE
ci: add concurrency control to build-and-publish workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
 


### PR DESCRIPTION
# Closes #523
<!--- Provide an overall summary of the pull request -->
This PR adds concurrency control to the [build-and-publish.yml](cci:7://file:///home/shubhraj/OpenSource/playground/.github/workflows/build-and-publish.yml:0:0-0:0) workflow to prevent redundant simultaneous deployments when multiple commits are pushed to `main` in quick succession.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added `concurrency` group to [build-and-publish.yml](cci:7://file:///home/shubhraj/OpenSource/playground/.github/workflows/build-and-publish.yml:0:0-0:0) with `cancel-in-progress: true`
- Ensures only one deployment runs at a time for the main branch

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- None

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
N/A - CI workflow change

### Related Issues
- Issue #523

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`