### PR TITLE
feat(ui): modernize editor headers with react-icons

### DIFF
--- a/src/pages/MainContainer.tsx
+++ b/src/pages/MainContainer.tsx
@@ -11,7 +11,7 @@ import "../styles/pages/MainContainer.css";
 import html2pdf from "html2pdf.js";
 import { Button } from "antd";
 import * as monaco from "monaco-editor";
-import { MdFormatAlignLeft } from "react-icons/md";
+import { MdFormatAlignLeft, MdChevronRight, MdExpandMore } from "react-icons/md";
 
 const MainContainer = () => {
   const agreementHtml = useAppStore((state) => state.agreementHtml);
@@ -86,7 +86,7 @@ const MainContainer = () => {
   const expandedCount = 3 - collapsedCount;
   const collapsedSize = 5;
   const expandedSize = expandedCount > 0 ? (100 - (collapsedCount * collapsedSize)) / expandedCount : 33;
-  
+
   // Create a key that changes when collapse state changes to force panel re-layout
   const panelKey = `${isModelCollapsed}-${isTemplateCollapsed}-${isDataCollapsed}`;
 
@@ -107,18 +107,19 @@ const MainContainer = () => {
                           <button
                             className="collapse-button"
                             onClick={toggleModelCollapse}
-                            style={{ 
-                              color: textColor, 
-                              background: 'transparent', 
-                              border: 'none', 
+                            style={{
+                              color: textColor,
+                              background: 'transparent',
+                              border: 'none',
                               cursor: 'pointer',
-                              fontSize: '16px',
-                              padding: '4px 8px',
-                              marginRight: '8px'
+                              display: 'flex',
+                              alignItems: 'center',
+                              padding: '4px',
+                              marginRight: '4px'
                             }}
                             title={isModelCollapsed ? "Expand" : "Collapse"}
                           >
-                            {isModelCollapsed ? '▶' : '▼'}
+                            {isModelCollapsed ? <MdChevronRight size={20} /> : <MdExpandMore size={20} />}
                           </button>
                           <span>Concerto Model</span>
                           <SampleDropdown setLoading={setLoading} />
@@ -140,18 +141,19 @@ const MainContainer = () => {
                           <button
                             className="collapse-button"
                             onClick={toggleTemplateCollapse}
-                            style={{ 
-                              color: textColor, 
-                              background: 'transparent', 
-                              border: 'none', 
+                            style={{
+                              color: textColor,
+                              background: 'transparent',
+                              border: 'none',
                               cursor: 'pointer',
-                              fontSize: '16px',
-                              padding: '4px 8px',
-                              marginRight: '8px'
+                              display: 'flex',
+                              alignItems: 'center',
+                              padding: '4px',
+                              marginRight: '4px'
                             }}
                             title={isTemplateCollapsed ? "Expand" : "Collapse"}
                           >
-                            {isTemplateCollapsed ? '▶' : '▼'}
+                            {isTemplateCollapsed ? <MdChevronRight size={20} /> : <MdExpandMore size={20} />}
                           </button>
                           <span>TemplateMark</span>
                         </div>
@@ -173,18 +175,19 @@ const MainContainer = () => {
                           <button
                             className="collapse-button"
                             onClick={toggleDataCollapse}
-                            style={{ 
-                              color: textColor, 
-                              background: 'transparent', 
-                              border: 'none', 
+                            style={{
+                              color: textColor,
+                              background: 'transparent',
+                              border: 'none',
                               cursor: 'pointer',
-                              fontSize: '16px',
-                              padding: '4px 8px',
-                              marginRight: '8px'
+                              display: 'flex',
+                              alignItems: 'center',
+                              padding: '4px',
+                              marginRight: '4px'
                             }}
                             title={isDataCollapsed ? "Expand" : "Collapse"}
                           >
-                            {isDataCollapsed ? '▶' : '▼'}
+                            {isDataCollapsed ? <MdChevronRight size={20} /> : <MdExpandMore size={20} />}
                           </button>
                           <span>JSON Data</span>
                         </div>
@@ -223,12 +226,12 @@ const MainContainer = () => {
               <div className="main-container-preview-panel tour-preview-panel" style={{ backgroundColor }}>
                 <div className={`main-container-preview-header ${backgroundColor === '#ffffff' ? 'main-container-preview-header-light' : 'main-container-preview-header-dark'}`}>
                   <span>Preview</span>
-                  <Button 
+                  <Button
                     onClick={handleDownloadPdf}
-                    loading={isDownloading} 
+                    loading={isDownloading}
                     style={{ marginLeft: "10px" }}
                   >
-                   Download PDF
+                    Download PDF
                   </Button>
                 </div>
                 <div className="main-container-preview-content" style={{ backgroundColor }}>


### PR DESCRIPTION
# Closes #542

This PR replaces the legacy text-based collapse indicators (`▶` / `▼`) in the editor headers with modern vector icons from `react-icons` (`MdChevronRight`, `MdExpandMore`). This aligns the UI with modern IDE standards (like VS Code).

### Changes
- Imported `MdChevronRight` and `MdExpandMore` from `react-icons/md`.
- Replaced the text content of the collapse buttons in [MainContainer.tsx](cci:7://file:///c:/Users/Lenovo/template-playground/src/pages/MainContainer.tsx:0:0-0:0) with these icons.
- Updated the button styling (flexbox alignment) to ensure the icons are centered and positioned correctly relative to the header text.

### Flags
- Existing lint errors in the project were ignored as they are unrelated to this specific UI change.

### Screenshots
### BEFORE

<img width="1212" height="279" alt="Screenshot 2026-01-12 115046" src="https://github.com/user-attachments/assets/178b5801-490f-4d89-b6c2-1ccfcf459281" />

### AFTER

<img width="1213" height="904" alt="Screenshot 2026-01-12 115134" src="https://github.com/user-attachments/assets/6e452154-7e1c-4db1-b76f-6241d2993a3e" />

### Related Issues
- Issue #542

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `Rahul-R79/542/modernize-editor-headers`