### PR TITLE
Fix: Added the alignment on the sidebar, adds position fixed on sidebar, includes marginal offset for app content.

### DIFF
--- a/src/components/PlaygroundSidebar.tsx
+++ b/src/components/PlaygroundSidebar.tsx
@@ -151,7 +151,7 @@ const PlaygroundSidebar = () => {
   ];
 
   return (
-    <aside className="playground-sidebar">
+    <aside className="playground-sidebar justify-start gap-5">
       <nav className="playground-sidebar-nav">
         {navTop.map(({ title, icon: Icon, component, onClick, active }) => (
           <Tooltip key={title} title={title} placement="right">

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -2,6 +2,9 @@
   @apply flex flex-row;
 }
 
+.app-layout .ant-layout-content {
+  margin-left: 64px;
+}
 .app-content-loading {
   @apply flex justify-center items-center min-h-[calc(100vh-64px)];
 }

--- a/src/styles/components/PlaygroundSidebar.css
+++ b/src/styles/components/PlaygroundSidebar.css
@@ -1,6 +1,11 @@
 /* PlaygroundSidebar Component Styles */
 .playground-sidebar {
-  @apply w-16 h-full bg-[#1B2540] text-white flex flex-col justify-between items-center py-6 shadow-md;
+  @apply w-16 bg-[#1B2540] text-white flex flex-col justify-between items-center py-6 shadow-md;
+  position: fixed;
+  left: 0;
+  top: 64px; /* Navbar height */
+  height: calc(100vh - 64px);
+  z-index: 100;
 }
 
 .playground-sidebar-nav {


### PR DESCRIPTION
Updated the `src/components/PlaygroungSidebar.tsx` file at the aside section to include the justify-start class to make the content icons all visible irrespective of the viewport height.

Updated the `src/App.css` to have a margin on the app content to accommodate the offset generated from the sidebar.

Updated `src/styles/components/PlaygroundSidebar.css` to add position fixed, as a result, removing the scroll on the sidebar component.

# Closes #518 
<!--- Provide an overall summary of the pull request -->

### Changes
This PR aligns the contents of the sidebar by adding a justify-start on the parent container, therefore aligning all the icons without needing to scroll.

The sidebar also contains a position fixed style to remove the unnecessary scroll on the current deployment.

This also adds a marginal offset onthe app content container to compensate for the position fixed on the sidebar, making the overall content centered. 

### Flags
- Website
- Sidebar

### Screenshots or Video
 * Before the fix ( at https://playground.accordproject.org/)
<img width="949" height="795" alt="Screenshot 2026-01-13 at 09 11 27" src="https://github.com/user-attachments/assets/2666846b-679e-4e65-96d4-6d1a9282c3cf" />
<br/>
 * After the fix
<img width="940" height="606" alt="Screenshot 2026-01-13 at 09 06 59" src="https://github.com/user-attachments/assets/bb7c0d07-c591-4503-9d17-ce09f29021d4" />

### Related Issues (but does not fix)
- Issue #515 
- Pull Request #485

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
