### PR TITLE
fix: show reset button correctly in AI config modal

### DIFF
--- a/src/components/AIConfigPopup.tsx
+++ b/src/components/AIConfigPopup.tsx
@@ -38,10 +38,11 @@ const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
       saveButton: {
         enabled: 'bg-blue-500 text-white hover:bg-blue-600',
         disabled: isDarkMode ? 'bg-gray-600 text-gray-400' : 'bg-gray-400 text-gray-200'
-      },
-      resetButton: isDarkMode
-        ? 'border-red-600 text-red-400 hover:bg-red-900 hover:border-red-500'
-        : 'border-red-500 text-red-600 hover:bg-red-50 hover:border-red-600'
+      },resetButton: isDarkMode
+  ? 'border-gray-600 text-gray-400 hover:bg-gray-700 hover:border-gray-500'
+  : 'border-gray-300 text-gray-500 hover:bg-gray-100 hover:border-gray-400'
+
+
     };
   }, [backgroundColor]);
 
@@ -143,7 +144,7 @@ const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
 
   return (
     <div className={`${theme.overlay} flex items-center justify-center z-[1050] twp`}>
-      <div className={`${theme.container} rounded-lg p-6 w-96 max-h-[90vh] overflow-y-auto`}>
+      <div className={`${theme.container} rounded-lg p-6 w-96 max-h-[90vh] overflow-y-auto `}>
         <div className="flex justify-between items-center mb-4">
           <h2 className={`text-xl font-bold ${theme.headerText}`}>AI Configuration</h2>
           <button
@@ -343,8 +344,9 @@ const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
                 </div>
               </div>
             )}
+            
           </div>
-
+           <div className=" bottom-0 bg-inherit pt-4 space-y-2">
            <button
             onClick={handleSave}
             disabled={!provider || !model || (provider !== 'ollama' && !apiKey) || (provider === 'openai-compatible' && !customEndpoint)}
@@ -362,9 +364,11 @@ const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
             className={`w-full py-2 rounded-lg border-2 transition-colors ${theme.resetButton}`}
           >
             Reset Configuration
-          </button>
+          </button></div>
         </div>
+        
       </div>
+      
     </div>
   );
 };


### PR DESCRIPTION
### Issue
Reset button existed but was not visible due to modal layout overflow.

### Fix
Refactored modal layout so footer buttons are always visible and accessible.

### Tested
- Light mode
- Dark mode

