### PR TITLE
fix(ux): disable bold/italic buttons in markdown toolbar without selection

### DIFF
--- a/src/components/TemplateMarkdownToolbar.tsx
+++ b/src/components/TemplateMarkdownToolbar.tsx
@@ -3,7 +3,7 @@ import { FaBold, FaItalic, FaLink, FaImage, FaListUl, FaListOl } from "react-ico
 import { useMarkdownEditorContext } from "../contexts/MarkdownEditorContext";
 
 export const TemplateMarkdownToolbar = () => {
-  const { commands: markdownEditorCommands } = useMarkdownEditorContext();
+  const { commands: markdownEditorCommands, hasSelection } = useMarkdownEditorContext();
 
   return (
     <div className="markdown-toolbar">
@@ -33,17 +33,19 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200 disabled:opacity-40 disabled:cursor-not-allowed"
         onClick={() => markdownEditorCommands?.toggleBold?.()}
         title="Bold"
+        disabled={!hasSelection}
       >
         <FaBold />
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className="border-none bg-transparent hover:bg-slate-200 disabled:opacity-40 disabled:cursor-not-allowed"
         onClick={() => markdownEditorCommands?.toggleItalic?.()}
         title="Italic"
+        disabled={!hasSelection}
       >
         <FaItalic />
       </button>

--- a/src/contexts/MarkdownEditorContext.tsx
+++ b/src/contexts/MarkdownEditorContext.tsx
@@ -15,6 +15,8 @@ export interface MarkdownEditorCommands {
 interface MarkdownEditorContextType {
   commands: MarkdownEditorCommands | undefined;
   setCommands: (commands: MarkdownEditorCommands | undefined) => void;
+  hasSelection: boolean;
+  setHasSelection: (hasSelection: boolean) => void;
 }
 
 const MarkdownEditorContext = createContext<MarkdownEditorContextType | undefined>(
@@ -25,9 +27,10 @@ export const MarkdownEditorProvider = ({ children }: { children: ReactNode }) =>
   const [commands, setCommands] = useState<MarkdownEditorCommands | undefined>(
     undefined
   );
+  const [hasSelection, setHasSelection] = useState(false);
 
   return (
-    <MarkdownEditorContext.Provider value={{ commands, setCommands }}>
+    <MarkdownEditorContext.Provider value={{ commands, setCommands, hasSelection, setHasSelection }}>
       {children}
     </MarkdownEditorContext.Provider>
   );

--- a/src/editors/editorsContainer/TemplateMarkdown.tsx
+++ b/src/editors/editorsContainer/TemplateMarkdown.tsx
@@ -11,7 +11,7 @@ function TemplateMarkdown() {
   const editorValue = useAppStore((state) => state.editorValue);
   const setEditorValue = useAppStore((state) => state.setEditorValue);
   const setTemplateMarkdown = useAppStore((state) => state.setTemplateMarkdown);
-  const { setCommands } = useMarkdownEditorContext();
+  const { setCommands, setHasSelection } = useMarkdownEditorContext();
 
   const { value, setValue } = useUndoRedo(
     editorValue,
@@ -25,8 +25,9 @@ function TemplateMarkdown() {
     return () => {
       // Clear commands when unmounting
       setCommands(undefined);
+      setHasSelection(false);
     };
-  }, [setCommands]);
+  }, [setCommands, setHasSelection]);
 
   const handleChange = (val: string | undefined) => {
     if (val !== undefined) {
@@ -40,6 +41,15 @@ function TemplateMarkdown() {
     editorRef.current = editor;
     const commands = createMarkdownCommands(editorRef);
     setCommands(commands);
+    
+    // Track selection changes
+    editor.onDidChangeCursorSelection(() => {
+      const selection = editor.getSelection();
+      if (selection) {
+        const hasText = !selection.isEmpty();
+        setHasSelection(hasText);
+      }
+    });
   };
 
   return (


### PR DESCRIPTION
### Description
This PR improves the editor UX by preventing formatting actions (Bold / Italic) from being applied when there is no active text selection.

Currently, clicking formatting buttons without selecting text inserts formatting markers into the editor repeatedly, which can lead to unexpected behavior and cluttered content. This change ensures formatting actions are only available when they can be meaningfully applied.

### Changes
- Disable Bold and Italic buttons when no text is selected

### Related Issues
- Pull Request #419 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
