### PR TITLE
Added expand/collapse toggle in template editor and UX improvements

### DIFF
--- a/src/components/TemplateMarkdownToolbar.tsx
+++ b/src/components/TemplateMarkdownToolbar.tsx
@@ -9,7 +9,7 @@ export const TemplateMarkdownToolbar = () => {
     <div className="markdown-toolbar">
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.toggleHeading1?.()}
         title="Heading 1"
       >
@@ -17,7 +17,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.toggleHeading2?.()}
         title="Heading 2"
       >
@@ -25,7 +25,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.toggleHeading3?.()}
         title="Heading 3"
       >
@@ -33,7 +33,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.toggleBold?.()}
         title="Bold"
       >
@@ -41,7 +41,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className="border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.toggleItalic?.()}
         title="Italic"
       >
@@ -49,7 +49,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className="border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.toggleUnorderedList?.()}
         title="Unordered list"
       >
@@ -57,7 +57,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className="border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.toggleOrderedList?.()}
         title="Ordered list"
       >
@@ -65,7 +65,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className="border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.insertLink?.()}
         title="Insert link"
       >
@@ -73,7 +73,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className="border-none bg-transparent hover:bg-slate-200 cursor-pointer p-1.5"
         onClick={() => markdownEditorCommands?.insertImage?.()}
         title="Insert image"
       >

--- a/src/pages/MainContainer.tsx
+++ b/src/pages/MainContainer.tsx
@@ -66,6 +66,7 @@ const MainContainer = () => {
     isTemplateCollapsed,
     isDataCollapsed,
     toggleModelCollapse,
+    toggleTemplateCollapse,
     toggleDataCollapse,
   } = useAppStore((state) => ({
     isAIChatOpen: state.isAIChatOpen,
@@ -76,6 +77,7 @@ const MainContainer = () => {
     isTemplateCollapsed: state.isTemplateCollapsed,
     isDataCollapsed: state.isDataCollapsed,
     toggleModelCollapse: state.toggleModelCollapse,
+    toggleTemplateCollapse: state.toggleTemplateCollapse,
     toggleDataCollapse: state.toggleDataCollapse,
   }));
 
@@ -99,7 +101,7 @@ const MainContainer = () => {
             <Panel defaultSize={62.5} minSize={30}>
               <div className="main-container-editors-panel" style={{ backgroundColor }}>
                 <PanelGroup key={panelKey} direction="vertical" className="main-container-editors-panel-group">
-                  <Panel minSize={3} maxSize={isModelCollapsed ? collapsedSize : 100} defaultSize={isModelCollapsed ? collapsedSize : expandedSize}>
+                  <Panel minSize={6} maxSize={isModelCollapsed ? collapsedSize : 100} defaultSize={isModelCollapsed ? collapsedSize : expandedSize}>
                     <div className="main-container-editor-section tour-concerto-model">
                       <div className={`main-container-editor-header ${backgroundColor === '#ffffff' ? 'main-container-editor-header-light' : 'main-container-editor-header-dark'}`}>
                         {/* Left side */}
@@ -132,13 +134,33 @@ const MainContainer = () => {
                       )}
                     </div>
                   </Panel>
+
                   <PanelResizeHandle className="main-container-panel-resize-handle-vertical" />
 
-                  <Panel minSize={20}>
+                  <Panel minSize={6}>
                     <MarkdownEditorProvider>
                       <div className="main-container-editor-section tour-template-mark">
                         <div className={`main-container-editor-header ${backgroundColor === '#ffffff' ? 'main-container-editor-header-light' : 'main-container-editor-header-dark'}`}>
-                          <span>TemplateMark</span>
+                          <div className="main-container-editor-header-left">
+                            <button
+                              className="collapse-button"
+                              onClick={toggleTemplateCollapse}
+                              style={{
+                                color: textColor,
+                                background: 'transparent',
+                                border: 'none',
+                                cursor: 'pointer',
+                                display: 'flex',
+                                alignItems: 'center',
+                                padding: '4px',
+                                marginRight: '4px'
+                              }}
+                              title={isTemplateCollapsed ? "Expand" : "Collapse"}
+                            >
+                              {isTemplateCollapsed ? <MdChevronRight size={20} /> : <MdExpandMore size={20} />}
+                            </button>
+                            <span>TemplateMark</span>
+                          </div>
                           <TemplateMarkdownToolbar />
                         </div>
                         <div className="main-container-editor-content" style={{ backgroundColor }}>
@@ -150,7 +172,7 @@ const MainContainer = () => {
 
                   <PanelResizeHandle className="main-container-panel-resize-handle-vertical" />
 
-                  <Panel minSize={3} maxSize={isDataCollapsed ? collapsedSize : 100} defaultSize={isDataCollapsed ? collapsedSize : expandedSize}>
+                  <Panel minSize={6} maxSize={isDataCollapsed ? collapsedSize : 100} defaultSize={isDataCollapsed ? collapsedSize : expandedSize}>
                     <div className="main-container-editor-section tour-json-data">
                       <div className={`main-container-editor-header ${backgroundColor === '#ffffff' ? 'main-container-editor-header-light' : 'main-container-editor-header-dark'}`}>
                         <div className="main-container-editor-header-left">


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
### Fix: added expand/collapse toggle in template editor and UX improvements
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<No issue, small UX fix>
<!--- Provide an overall summary of the pull request -->

### Changes
- Added collapse/expand toggle button for template editor 
- Prevented title from hiding when panel is collapsed by changing minSize = 3 to minSize = 6
- Added p-1.5 padding and cursor-pointer to TemplateMark tools for better UX

### Flags
- Small UI/UX fix; no backend logic affected
- Make sure to check the panel behavior on collapse/expand to confirm title visibility

### Screenshots or Video
Before: 

https://github.com/user-attachments/assets/a9076595-e414-41fd-a19f-3553b8984360

After: 

https://github.com/user-attachments/assets/cab713e6-1a52-4df9-a6fa-952b238352bf


### Related Issues
- None (small UX fix)
- Pull Request #<N/A>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
