### PR TITLE
Fix keyboard accessibility issue in sidebar

### DIFF
--- a/src/components/PlaygroundSidebar.tsx
+++ b/src/components/PlaygroundSidebar.tsx
@@ -155,12 +155,11 @@ const PlaygroundSidebar = () => {
       <nav className="playground-sidebar-nav">
         {navTop.map(({ title, icon: Icon, component, onClick, active }) => (
           <Tooltip key={title} title={title} placement="right">
-          <div
-            role="button"
+          <button
             aria-label={title}
             tabIndex={0}
             onClick={onClick}
-            className={`group playground-sidebar-nav-item ${
+            className={`group border-none bg-transparent playground-sidebar-nav-item ${
               active ? 'playground-sidebar-nav-item-active' : 'playground-sidebar-nav-item-inactive'
             } tour-${title.toLowerCase().replace(' ', '-')}`}
           >
@@ -172,7 +171,7 @@ const PlaygroundSidebar = () => {
               <Icon size={20} />
             ) : null}
             <span className="playground-sidebar-nav-item-title">{title}</span>
-          </div>
+          </button>
           </Tooltip>
         ))}
       </nav>
@@ -180,16 +179,15 @@ const PlaygroundSidebar = () => {
       <nav className="playground-sidebar-nav-bottom">
         {navBottom.map(({ title, icon: Icon, onClick }) => (
           <Tooltip key={title} title={title} placement="right">
-          <div
-            role="button"
+          <button
             aria-label={title}
             tabIndex={0}
             onClick={onClick}
-            className={`group playground-sidebar-nav-bottom-item tour-${title.toLowerCase().replace(' ', '-')}`}
+            className={`group border-none bg-transparent playground-sidebar-nav-bottom-item tour-${title.toLowerCase().replace(' ', '-')}`}
           >
             <Icon size={18} />
             <span className="playground-sidebar-nav-item-title">{title}</span>
-          </div>
+          </button>
           </Tooltip>
         ))}
       </nav>


### PR DESCRIPTION
## Description

This PR aims to close #587 . Replaced non-semantic elements with the semantic ones to make sure pressing Enter key triggers the button. This helps in keyboard accessibility of webpage. 

---

## Changes Made

* In PlaygroundSidebar.tsx replaced the div tags with the button tags to make sure the components of sidebar is recognised by the browser API.
* This allows the buttons to be trigged when Enter key is pressed while the button is focused. 

---

## Before

https://github.com/user-attachments/assets/40767011-dcae-472a-be1d-14202f4b4425


---

## After


https://github.com/user-attachments/assets/9f4afdc9-147a-44f5-828d-7e655123602d

---

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`