### PR TITLE
fix(eslint): prevent parsing errors on config files

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,27 +1,46 @@
 /* eslint-env node */
 
 module.exports = {
-  root: true,
-  env: { browser: true, es2020: true },
-  extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended-requiring-type-checking',
-    'plugin:react-hooks/recommended',
-  ],
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: true,
-    tsconfigRootDir: __dirname,
-  },
-  plugins: ['react-refresh'],
-  rules: {
-    'react-refresh/only-export-components': [
-      'warn',
-      { allowConstantExport: true },
-    ],
-    '@typescript-eslint/no-non-null-assertion': 'off',
-  },
-}
+	root: true,
+
+	env: {
+		browser: true,
+		es2020: true,
+		node: true,
+	},
+
+	extends: ['eslint:recommended', 'plugin:react-hooks/recommended'],
+
+	overrides: [
+		{
+			files: ['src/**/*.{ts,tsx}'],
+			parser: '@typescript-eslint/parser',
+			parserOptions: {
+				project: true,
+				tsconfigRootDir: __dirname,
+			},
+			extends: [
+				'plugin:@typescript-eslint/recommended',
+				'plugin:@typescript-eslint/recommended-requiring-type-checking',
+			],
+			plugins: ['react-refresh'],
+			rules: {
+				'react-refresh/only-export-components': [
+					'warn',
+					{allowConstantExport: true},
+				],
+				'@typescript-eslint/no-non-null-assertion': 'off',
+			},
+		},
+
+		{
+			files: ['*.config.js', '*.config.ts', '.eslintrc.cjs'],
+			parserOptions: {
+				project: null,
+			},
+			env: {
+				node: true,
+			},
+		},
+	],
+};


### PR DESCRIPTION
Closes #624

This PR fixes ESLint parsing errors on configuration files by limiting
type-aware linting to source files only.

### Changes
- Applied ESLint overrides for config files
- Kept strict type-checking for application source code

### Flags
- Tooling-only change
- No runtime or behavior changes

### Related Issues
- Issue #624 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
