### PR TITLE
fix: replace esm import with require in config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,22 +1,23 @@
-import { scopedPreflightStyles, isolateInsideOfContainer } from 'tailwindcss-scoped-preflight';
+const {
+	scopedPreflightStyles,
+	isolateInsideOfContainer,
+} = require('tailwindcss-scoped-preflight');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  corePlugins: {
-    preflight: false,
-  },
-  content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [
-    require('@tailwindcss/typography'),
-    scopedPreflightStyles({
-      isolationStrategy: isolateInsideOfContainer('.twp', {
-        except: '.no-twp',
-      }),
-    }),
-  ],
-}
+	corePlugins: {
+		preflight: false,
+	},
+	content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+	theme: {
+		extend: {},
+	},
+	plugins: [
+		require('@tailwindcss/typography'),
+		scopedPreflightStyles({
+			isolationStrategy: isolateInsideOfContainer('.twp', {
+				except: '.no-twp',
+			}),
+		}),
+	],
+};


### PR DESCRIPTION
Closes #626 

This PR fixes an ESLint parsing error by ensuring `tailwind.config.js`
uses CommonJS syntax consistently.

### Changes
- Replaced `import` with `require` in Tailwind config

### Flags
- Config-only change
- No impact on runtime behavior

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`