### PR TITLE
feat: add not found page for unknown routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9721,9 +9721,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001723",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
-      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
+      "version": "1.0.30001766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
+      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import PlaygroundSidebar from "./components/PlaygroundSidebar";
 import "./styles/App.css";
 import AIConfigPopup from "./components/AIConfigPopup";
 import { loadConfigFromLocalStorage } from "./ai-assistant/chatRelay";
+import NotFound from "./pages/NotFound";
 
 const { Content } = Layout;
 
@@ -110,7 +111,7 @@ const App = () => {
       <Layout style={{ height: "100vh" }}>
         <Navbar />
         <Layout
-          className="app-layout"
+          className="app-layout grid"
           style={{
             backgroundColor,
             height: "calc(100vh - 64px)",
@@ -149,6 +150,9 @@ const App = () => {
               <Route path="module2" element={<LearnContent file="module2.md" />} />
               <Route path="module3" element={<LearnContent file="module3.md" />} />
             </Route>
+
+             <Route path="*" element={<NotFound />} />
+            
           </Routes>
         </Layout>
       </Layout>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom';
+
+const NotFound = () => {
+  return (
+    <div
+      style={{
+        height: '90%',       
+        display: 'grid',
+        placeItems: 'center',
+        textAlign: 'center',
+        padding: '2rem',
+      }}
+    >
+      <div>
+        <h1
+          className="text-[var(--text-color)]"
+          style={{ fontSize: '3rem', marginBottom: '0.25rem' }}
+        >
+          404
+        </h1>
+
+        <p
+          className="text-[var(--text-color)]"
+          style={{ fontSize: '1.25rem', marginBottom: '1.5rem' }}
+        >
+          Oops! The page you’re looking for doesn’t exist.
+        </p>
+
+        <Link
+          to="/"
+          style={{
+            color: '#19c6c7',
+            fontWeight: 600,
+            textDecoration: 'none',
+          }}
+        >
+          Go back to Home
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
# Closes #634

This PR introduces a dedicated Not Found (404) page that is displayed when users
navigate to unknown routes.

### Changes
- Added a NotFound page component
- Registered a wildcard (`*`) route to handle unknown paths
- Included a link to return users back to the home page

### Flags
- UI-only change
- No impact on application logic or APIs

### Screenshots or Video
**Before:**
<img width="2890" height="2034" alt="image" src="https://github.com/user-attachments/assets/932ba257-8b0e-4aab-b0d1-26b196e9e959" />

**After:**
<img width="2890" height="1942" alt="image" src="https://github.com/user-attachments/assets/39dd1224-d745-41e2-8cc4-468bbd2c8993" />

### Related Issues
- Issue #634

### Author Checklist
- [x] Ensure you provide a DCO sign-off using the `--signoff` option of git commit
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commit messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:<branch-name>`
