### PR TITLE
refactor: use theme variables for toolbar hover styling

### DIFF
--- a/src/components/TemplateMarkdownToolbar.tsx
+++ b/src/components/TemplateMarkdownToolbar.tsx
@@ -1,86 +1,102 @@
-import { LuHeading1, LuHeading2, LuHeading3 } from "react-icons/lu";
-import { FaBold, FaItalic, FaLink, FaImage, FaListUl, FaListOl } from "react-icons/fa";
-import { useMarkdownEditorContext } from "../contexts/MarkdownEditorContext";
+import {
+	FaBold,
+	FaImage,
+	FaItalic,
+	FaLink,
+	FaListOl,
+	FaListUl,
+} from 'react-icons/fa';
+import {LuHeading1, LuHeading2, LuHeading3} from 'react-icons/lu';
+import {useMarkdownEditorContext} from '../contexts/MarkdownEditorContext';
 
 export const TemplateMarkdownToolbar = () => {
-  const { commands: markdownEditorCommands } = useMarkdownEditorContext();
+	const {commands: markdownEditorCommands} = useMarkdownEditorContext();
 
-  return (
-    <div className="markdown-toolbar">
-      <button
-        type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.toggleHeading1?.()}
-        title="Heading 1"
-      >
-        <LuHeading1 size={15} />
-      </button>
-      <button
-        type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.toggleHeading2?.()}
-        title="Heading 2"
-      >
-        <LuHeading2 size={15} />
-      </button>
-      <button
-        type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.toggleHeading3?.()}
-        title="Heading 3"
-      >
-        <LuHeading3 size={15} />
-      </button>
-      <button
-        type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.toggleBold?.()}
-        title="Bold"
-      >
-        <FaBold />
-      </button>
-      <button
-        type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.toggleItalic?.()}
-        title="Italic"
-      >
-        <FaItalic />
-      </button>
-      <button
-        type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.toggleUnorderedList?.()}
-        title="Unordered list"
-      >
-        <FaListUl />
-      </button>
-      <button
-        type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.toggleOrderedList?.()}
-        title="Ordered list"
-      >
-        <FaListOl />
-      </button>
-      <button
-        type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.insertLink?.()}
-        title="Insert link"
-      >
-        <FaLink />
-      </button>
-      <button
-        type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
-        onClick={() => markdownEditorCommands?.insertImage?.()}
-        title="Insert image"
-      >
-        <FaImage />
-      </button>
-    </div>
-  );
+	const baseButtonClass =
+		'border-none bg-transparent p-1 rounded text-[var(--text-color)] hover:bg-[var(--hover-bg-color)]';
+
+	return (
+		<div className="markdown-toolbar">
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.toggleHeading1?.()}
+				title="Heading 1"
+			>
+				<LuHeading1 size={15} />
+			</button>
+
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.toggleHeading2?.()}
+				title="Heading 2"
+			>
+				<LuHeading2 size={15} />
+			</button>
+
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.toggleHeading3?.()}
+				title="Heading 3"
+			>
+				<LuHeading3 size={15} />
+			</button>
+
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.toggleBold?.()}
+				title="Bold"
+			>
+				<FaBold />
+			</button>
+
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.toggleItalic?.()}
+				title="Italic"
+			>
+				<FaItalic />
+			</button>
+
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.toggleUnorderedList?.()}
+				title="Unordered list"
+			>
+				<FaListUl />
+			</button>
+
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.toggleOrderedList?.()}
+				title="Ordered list"
+			>
+				<FaListOl />
+			</button>
+
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.insertLink?.()}
+				title="Insert link"
+			>
+				<FaLink />
+			</button>
+
+			<button
+				type="button"
+				className={baseButtonClass}
+				onClick={() => markdownEditorCommands?.insertImage?.()}
+				title="Insert image"
+			>
+				<FaImage />
+			</button>
+		</div>
+	);
 };
-
-


### PR DESCRIPTION
# Closes #636

This PR updates the markdown toolbar button styling to use existing theme variables for hover background colors instead of hardcoded Tailwind utilities.

### Changes
- Replaced hardcoded hover background classes with `hover:bg-[var(--hover-bg-color)]`
- Ensured toolbar icons inherit `--text-color` for consistent theming

### Flags
- UI-only change
- No functional or behavioral impact

### Screenshots or Video
**Before:**
<img width="2758" height="640" alt="image" src="https://github.com/user-attachments/assets/2186d315-159e-4789-b866-78db2360d562" />

**After:**
<img width="2758" height="640" alt="image" src="https://github.com/user-attachments/assets/705f88e8-3944-4ec4-abe1-0627a3ae6986" />

### Related Issues
- Issue #636 

### Author Checklist
- [x] Ensure you provide a DCO sign-off using the `--signoff` option of git commit
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commit messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:<branch-name>`
