### PR TITLE
docs: fix minor typos

### DIFF
--- a/src/content/intro.md
+++ b/src/content/intro.md
@@ -6,4 +6,4 @@ This tutorial has the following modules:
 
 - [Module 1](https://playground.accordproject.org/learn/module1): Create a Concerto model for your template.
 - [Module 2](https://playground.accordproject.org/learn/module2): Draft a TemplateMark template.
-- [Module 3](https://playground.accordproject.org/learn/module3): Pass some data to the TemplateMark template conforming to the shape defined by the Concerto Model
+- [Module 3](https://playground.accordproject.org/learn/module3): Pass some data to the TemplateMark template conforming to the shape defined by the Concerto Model.

--- a/src/content/module1.md
+++ b/src/content/module1.md
@@ -2,7 +2,7 @@
 
 ## _Create a Concerto model for your template._
 
-Learn more about Concerto modelling language and its runtime [here](https://concerto.accordproject.org/)
+Learn more about Concerto modelling language and its runtime [here](https://concerto.accordproject.org/).
 
 - Step 1: Open the Concerto Model editor and define the [Model Namespace](https://concerto.accordproject.org/docs/design/specification/model-namespaces).
 

--- a/src/content/module2.md
+++ b/src/content/module2.md
@@ -2,7 +2,9 @@
 
 ## _Draft a TemplateMark template._
 
-Next define the [TemplateMark](https://github.com/accordproject/markdown-transform?tab=readme-ov-file#templatemark-dom) for the template in the TemplateMark Editor. In this case it is the plain-text world `"Hello"` followed by a space, then the variable `message` followed by `"."`.
+Next define the [TemplateMark](https://github.com/accordproject/markdown-transform?tab=readme-ov-file#templatemark-dom) for the template in the TemplateMark Editor. 
+
+In this case, it is the plain-text word `"Hello"` followed by a space, then the variable `message` followed by `"."`.
 
 ```
 Hello {{message}}.

--- a/src/content/module3.md
+++ b/src/content/module3.md
@@ -4,7 +4,7 @@
 
 Generate some data to the TemplateMark template conforming to the shape defined by the Concerto Model.
 
-Define an instance of the `helloworld@1.0.0.TemplateData` data model. In this case setting the value of the `message` property to the string "World".
+Define an instance of the `helloworld@1.0.0.TemplateData` data model. In this case, setting the value of the `message` property to the string `"World"`.
 
 ```
 const data = {


### PR DESCRIPTION
This PR fixes minor typos and wording issues in the documentation.
No functional changes are introduced.