### PR TITLE
feat: add UI warning for unsupported local file paths in Markdown editor

### DIFF
--- a/src/editors/MarkdownEditor.tsx
+++ b/src/editors/MarkdownEditor.tsx
@@ -1,10 +1,9 @@
-import { lazy, Suspense, useMemo, useCallback, useEffect } from "react";
+import { lazy, Suspense, useMemo, useCallback, useEffect, useRef } from "react";
 import useAppStore from "../store/store";
 import { useMonaco } from "@monaco-editor/react";
 import { useCodeSelection } from "../components/CodeSelectionMenu";
 import type { editor } from "monaco-editor";
 import { registerAutocompletion } from "../ai-assistant/autocompletion";
-
 
 const MonacoEditor = lazy(() =>
   import("@monaco-editor/react").then((mod) => ({ default: mod.Editor }))
@@ -20,6 +19,9 @@ export default function MarkdownEditor({
   onEditorReady?: (editor: editor.IStandaloneCodeEditor) => void;
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("markdown");
+  
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+
   const { backgroundColor, textColor, aiConfig } = useAppStore((state) => ({
     backgroundColor: state.backgroundColor,
     textColor: state.textColor,
@@ -32,6 +34,63 @@ export default function MarkdownEditor({
     [backgroundColor]
   );
 
+  // --- 1. ROBUST VALIDATION LOGIC ---
+  useEffect(() => {
+    if (!monaco || !editorRef.current) return;
+
+    const editorInstance = editorRef.current;
+    const model = editorInstance.getModel();
+
+    if (!model) return;
+
+    const validate = () => {
+      const text = model.getValue();
+      const markers: editor.IMarkerData[] = [];
+      
+      // Standard JS Regex (Much safer than Monaco's string-based regex)
+      // Matches: ![...](file://...) OR ![...](C:...) OR ![...](/...)
+      const regex = /!\[.*?\]\(\s*(?:file:\/\/|\\\\|[a-zA-Z]:).+?\)/g;
+      
+      let match;
+      while ((match = regex.exec(text)) !== null) {
+        // We found a bad link! Now calculate where it is.
+        const startPos = model.getPositionAt(match.index);
+        const endPos = model.getPositionAt(match.index + match[0].length);
+        
+        markers.push({
+          severity: monaco.MarkerSeverity.Warning,
+          startLineNumber: startPos.lineNumber,
+          startColumn: startPos.column,
+          endLineNumber: endPos.lineNumber,
+          endColumn: endPos.column,
+          message: "Local file paths are not supported. Please use an HTTPS URL.",
+          source: "Markdown Editor"
+        });
+      }
+
+      // Debug Log
+      if (markers.length > 0) {
+        console.log("✅ Validation: Found local paths!", markers);
+      }
+
+      monaco.editor.setModelMarkers(model, "local-path-check", markers);
+    };
+
+    // Run immediately
+    validate();
+
+    // Run on change
+    const subscription = model.onDidChangeContent(() => {
+      validate();
+    });
+
+    return () => {
+      subscription.dispose();
+    };
+
+  }, [monaco, editorRef.current]); 
+
+  // --- (Rest of the file remains standard) ---
   useEffect(() => {
     if (monaco) {
       const defineTheme = (name: string, base: "vs" | "vs-dark") => {
@@ -47,10 +106,8 @@ export default function MarkdownEditor({
           },
         });
       };
-
       defineTheme("lightTheme", "vs");
       defineTheme("darkTheme", "vs-dark");
-
       monaco.editor.setTheme(themeName);
     }
   }, [monaco, backgroundColor, textColor, themeName]);
@@ -79,14 +136,13 @@ export default function MarkdownEditor({
   }), [aiConfig?.enableInlineSuggestions]);
 
   const handleEditorDidMount = (editorInstance: editor.IStandaloneCodeEditor) => {
+    editorRef.current = editorInstance;
     editorInstance.onDidChangeCursorSelection(() => {
       handleSelection(editorInstance);
     });
-
     if (monaco) {
       registerAutocompletion('markdown', monaco);
     }
-
     if (onEditorReady) {
       onEditorReady(editorInstance);
     }


### PR DESCRIPTION
# Closes #650 

The Template Playground currently fails silently when a user attempts to use a local file path (e.g., `C:\Users\image.png`) in the markdown image syntax. This PR improves the User Experience (UX) by detecting these paths and providing immediate visual feedback, guiding users to use supported HTTPS URLs or Base64 strings instead.

### Changes
- Modified `MarkdownEditor.tsx` to implement real-time validation using `useEffect` and Regex. It now scans for local path patterns (e.g., `file://`, `C:`, or `\`) and applies a standard Monaco Editor "Marker" (Warning).
- Updated `ProblemPanel.tsx` to subscribe to Monaco Editor markers via `useMonaco`. This ensures that validation warnings from the editor now appear correctly in the global "Problems" list at the bottom of the UI.

### Flags
- None.

### Screenshots 
before : Silent failure when entering unsupported local file paths (image fails to load without explanation).
<img width="1916" height="880" alt="Screenshot 2026-02-01 184826" src="https://github.com/user-attachments/assets/ff7656f8-b062-4c2b-8674-c84fadc614d4" />

after : Clear visual warning (squiggly line & problem panel entry) informing the user that local paths are not supported.
<img width="627" height="488" alt="Screenshot 2026-02-01 193254" src="https://github.com/user-attachments/assets/27e219a1-ef95-4ae5-b19c-f0b71b092345" />


<img width="1919" height="868" alt="Screenshot 2026-02-01 193154" src="https://github.com/user-attachments/assets/eb360b84-e313-419e-96b5-71073737410c" />


### Related Issues
- Issue #650 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:feature/local-image-warning`

