### PR TITLE
feat: improve accessibility for toolbar and chat panel

### DIFF
--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -244,6 +244,7 @@ export const AIChatPanel = () => {
             onClick={() => setAIConfigOpen(true)}
             className="text-gray-500 hover:text-gray-800"
             title="AI Settings"
+            aria-label="AI Settings"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -269,6 +270,7 @@ export const AIChatPanel = () => {
             onClick={resetChat}
             className="text-gray-500 hover:text-gray-800"
             title="Reset Chat"
+            aria-label="Reset Chat"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -289,6 +291,7 @@ export const AIChatPanel = () => {
             onClick={() => setAIChatOpen(false)}
             className="text-gray-500 hover:text-gray-800"
             title="Close"
+            aria-label="Close Chat"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -372,6 +375,7 @@ export const AIChatPanel = () => {
                 <button
                 onClick={() => setPromptPreset(null)}
                 className="text-indigo-200 hover:text-white transition-colors"
+                aria-label="Clear preset"
                 >
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -414,6 +418,7 @@ export const AIChatPanel = () => {
                     className={`ml-1 focus:outline-none ${theme.contextButtons.templateMark.cross}`}
                     tabIndex={-1}
                     type="button"
+                    aria-label="Remove TemplateMark context"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -448,6 +453,7 @@ export const AIChatPanel = () => {
                     className={`ml-1 focus:outline-none ${theme.contextButtons.concerto.cross}`}
                     tabIndex={-1}
                     type="button"
+                    aria-label="Remove Concerto context"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -482,6 +488,7 @@ export const AIChatPanel = () => {
                     className={`ml-1 focus:outline-none ${theme.contextButtons.data.cross}`}
                     tabIndex={-1}
                     type="button"
+                    aria-label="Remove Data context"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -526,6 +533,7 @@ export const AIChatPanel = () => {
                   }`}
                   title="Select Prompt Mode"
                   disabled={chatState.isLoading}
+                  aria-label="Select Prompt Mode"
               >
                   <svg
                       xmlns="http://www.w3.org/2000/svg"

--- a/src/components/TemplateMarkdownToolbar.tsx
+++ b/src/components/TemplateMarkdownToolbar.tsx
@@ -12,6 +12,7 @@ export const TemplateMarkdownToolbar = () => {
         className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.toggleHeading1?.()}
         title="Heading 1"
+        aria-label="Heading 1"
       >
         <LuHeading1 size={15} />
       </button>
@@ -20,6 +21,7 @@ export const TemplateMarkdownToolbar = () => {
         className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.toggleHeading2?.()}
         title="Heading 2"
+        aria-label="Heading 2"
       >
         <LuHeading2 size={15} />
       </button>
@@ -28,6 +30,7 @@ export const TemplateMarkdownToolbar = () => {
         className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.toggleHeading3?.()}
         title="Heading 3"
+        aria-label="Heading 3"
       >
         <LuHeading3 size={15} />
       </button>
@@ -36,6 +39,7 @@ export const TemplateMarkdownToolbar = () => {
         className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.toggleBold?.()}
         title="Bold"
+        aria-label="Bold"
       >
         <FaBold />
       </button>
@@ -44,6 +48,7 @@ export const TemplateMarkdownToolbar = () => {
         className="border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.toggleItalic?.()}
         title="Italic"
+        aria-label="Italic"
       >
         <FaItalic />
       </button>
@@ -52,6 +57,7 @@ export const TemplateMarkdownToolbar = () => {
         className="border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.toggleUnorderedList?.()}
         title="Unordered list"
+        aria-label="Unordered list"
       >
         <FaListUl />
       </button>
@@ -60,6 +66,7 @@ export const TemplateMarkdownToolbar = () => {
         className="border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.toggleOrderedList?.()}
         title="Ordered list"
+        aria-label="Ordered list"
       >
         <FaListOl />
       </button>
@@ -68,6 +75,7 @@ export const TemplateMarkdownToolbar = () => {
         className="border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.insertLink?.()}
         title="Insert link"
+        aria-label="Insert link"
       >
         <FaLink />
       </button>
@@ -76,6 +84,7 @@ export const TemplateMarkdownToolbar = () => {
         className="border-none bg-transparent hover:bg-slate-200"
         onClick={() => markdownEditorCommands?.insertImage?.()}
         title="Insert image"
+        aria-label="Insert image"
       >
         <FaImage />
       </button>


### PR DESCRIPTION
# Closes #N/A

<!--- Provide an overall summary of the pull request -->

This PR enhances the accessibility of the `TemplateMarkdownToolbar` and `AIChatPanel` components. It ensures that all icon-only buttons have descriptive ARIA labels for screen readers 

### Changes

<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->

- Modified `src/components/TemplateMarkdownToolbar.tsx` to add `aria-label` attributes to all formatting buttons (Heading, Bold, Italic, Link, Image, Lists).
- Modified `src/components/AIChatPanel.tsx` to add `aria-label` attributes to the AI Settings, Reset Chat, Close Chat, Clear Preset, and Context Removal buttons.
- Added `aria-label` to the Prompt Mode dropdown toggle in `AIChatPanel.tsx`.

### Flags

- N/A


### Screenshots or Video

- N/A

### Related Issues

- Issue #N/A

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests (Manual verification performed).
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:feat/a11y-improvements`
