### PR TITLE
fix: apply theme color to problem panel badge

### DIFF
--- a/src/components/ProblemPanel.tsx
+++ b/src/components/ProblemPanel.tsx
@@ -1,150 +1,185 @@
-import React, { useMemo } from 'react';
+import React, {useMemo} from 'react';
 import useAppStore from '../store/store';
 import '../styles/components/ProblemPanel.css';
 
 export interface ProblemItem {
-  id: string;
-  type: 'error' | 'warning' | 'info';
-  message: string;
-  source?: string;
-  line?: number;
-  column?: number;
-  timestamp: Date;
+	id: string;
+	type: 'error' | 'warning' | 'info';
+	message: string;
+	source?: string;
+	line?: number;
+	column?: number;
+	timestamp: Date;
 }
 
 const ProblemPanel: React.FC = () => {
-  const { error, backgroundColor, textColor } = useAppStore((state) => ({ 
-    error: state.error,
-    backgroundColor: state.backgroundColor,
-    textColor: state.textColor
-  }));
-  
-  const parseError = (errorMessage: string) => {
-    const errors: Omit<ProblemItem, 'id' | 'timestamp'>[] = [];
-    
-    const errorParts = errorMessage.split(/\n(?=Error:|TypeError:|SyntaxError:|ReferenceError:)/);
-    
-    errorParts.forEach((part) => {
-      if (!part.trim()) return;
-      
-      const lineMatch = part.match(/[Ll]ine (\d+)/);
-      const columnMatch = part.match(/[Cc]olumn? (\d+)/);
-      
-      let type: 'error' | 'warning' | 'info' = 'error';
-      let source = 'Template Compilation';
-      
-      if (part.includes('Warning') || part.includes('warning')) {
-        type = 'warning';
-      } else if (part.includes('Info') || part.includes('info')) {
-        type = 'info';
-      }
-      
-      if (part.includes('model') || part.includes('Model') || part.includes('CTO')) {
-        source = 'Concerto Model';
-      } else if (part.includes('template') || part.includes('Template') || part.includes('mark')) {
-        source = 'TemplateMark';
-      } else if (part.includes('data') || part.includes('JSON')) {
-        source = 'JSON Data';
-      }
-      
-      errors.push({
-        type,
-        message: part.trim(),
-        source,
-        line: lineMatch ? parseInt(lineMatch[1]) : undefined,
-        column: columnMatch ? parseInt(columnMatch[1]) : undefined,
-      });
-    });
-    
-    return errors;
-  };
-  
-  const problems = useMemo((): ProblemItem[] => {
-    if (!error) return [];
-    
-    const parsedErrors = parseError(error);
-    return parsedErrors.map((parsedError, index) => ({
-      id: `error-${Date.now()}-${index}`,
-      timestamp: new Date(),
-      ...parsedError
-    }));
-  }, [error]);
-  
+	const {error, backgroundColor, textColor} = useAppStore(state => ({
+		error: state.error,
+		backgroundColor: state.backgroundColor,
+		textColor: state.textColor,
+	}));
 
-  const formatTimestamp = (timestamp: Date) => {
-    return timestamp.toLocaleTimeString('en-US', { 
-      hour12: false, 
-      hour: '2-digit', 
-      minute: '2-digit', 
-      second: '2-digit' 
-    });
-  };
+	const parseError = (errorMessage: string) => {
+		const errors: Omit<ProblemItem, 'id' | 'timestamp'>[] = [];
 
-  return (
-    <div className="problem-panel-container" style={{ backgroundColor }}>
-      <div className={`problem-panel-header ${backgroundColor === '#ffffff' ? 'problem-panel-header-light' : 'problem-panel-header-dark'}`}>
-        <span className="problem-panel-title">Problems</span>
-      </div>
-      <div className="problem-panel-content" style={{ backgroundColor }}>
-        {problems.length === 0 ? (
-          <div className="problem-panel-empty-state">
-            <div className="problem-panel-empty-state-content">
-              <div className="problem-panel-empty-state-icon">✨</div>
-              <div className="problem-panel-empty-state-text" style={{ color: textColor }}>No problems detected</div>
-            </div>
-          </div>
-        ) : (
-          <div className="problem-panel-problems-list">
-            {problems.map((problem) => (
-              <div
-                key={problem.id}
-                className={`problem-panel-problem-item ${
-                  backgroundColor === '#ffffff' ? 'problem-panel-problem-item-light' : 'problem-panel-problem-item-dark'
-                } ${
-                  problem.type === 'error' ? 'problem-panel-problem-item-error' :
-                  problem.type === 'warning' ? 'problem-panel-problem-item-warning' :
-                  'problem-panel-problem-item-info'
-                }`}
-              >
-                <div className="problem-panel-problem-content">
-                  <div className="problem-panel-problem-details">
-                    <div className="problem-panel-problem-meta">
-                      <div className="problem-panel-problem-tags">
-                        <span className="problem-panel-problem-type-badge">
-                          {problem.type.toUpperCase()}
-                        </span>
-                        {problem.source && (
-                          <span className="problem-panel-problem-source" style={{ color: textColor }}>
-                            {problem.source}
-                          </span>
-                        )}
-                        {(problem.line || problem.column) && (
-                          <span className="problem-panel-problem-location" style={{ color: textColor }}>
-                            {problem.line && `Line ${problem.line}`}
-                            {problem.line && problem.column && ':'}
-                            {problem.column && `Col ${problem.column}`}
-                          </span>
-                        )}
-                      </div>
-                      <span className="problem-panel-problem-timestamp" style={{ color: textColor }}>
-                        {formatTimestamp(problem.timestamp)}
-                      </span>
-                    </div>
-                    
-                    <div className="problem-panel-problem-message-container">
-                      <p className="problem-panel-problem-message" style={{ color: textColor }}>
-                        {problem.message}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+		const errorParts = errorMessage.split(
+			/\n(?=Error:|TypeError:|SyntaxError:|ReferenceError:)/,
+		);
+
+		errorParts.forEach(part => {
+			if (!part.trim()) return;
+
+			const lineMatch = part.match(/[Ll]ine (\d+)/);
+			const columnMatch = part.match(/[Cc]olumn? (\d+)/);
+
+			let type: 'error' | 'warning' | 'info' = 'error';
+			let source = 'Template Compilation';
+
+			if (part.includes('Warning') || part.includes('warning')) {
+				type = 'warning';
+			} else if (part.includes('Info') || part.includes('info')) {
+				type = 'info';
+			}
+
+			if (
+				part.includes('model') ||
+				part.includes('Model') ||
+				part.includes('CTO')
+			) {
+				source = 'Concerto Model';
+			} else if (
+				part.includes('template') ||
+				part.includes('Template') ||
+				part.includes('mark')
+			) {
+				source = 'TemplateMark';
+			} else if (part.includes('data') || part.includes('JSON')) {
+				source = 'JSON Data';
+			}
+
+			errors.push({
+				type,
+				message: part.trim(),
+				source,
+				line: lineMatch ? parseInt(lineMatch[1]) : undefined,
+				column: columnMatch ? parseInt(columnMatch[1]) : undefined,
+			});
+		});
+
+		return errors;
+	};
+
+	const problems = useMemo((): ProblemItem[] => {
+		if (!error) return [];
+
+		const parsedErrors = parseError(error);
+		return parsedErrors.map((parsedError, index) => ({
+			id: `error-${Date.now()}-${index}`,
+			timestamp: new Date(),
+			...parsedError,
+		}));
+	}, [error]);
+
+	const formatTimestamp = (timestamp: Date) => {
+		return timestamp.toLocaleTimeString('en-US', {
+			hour12: false,
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit',
+		});
+	};
+
+	return (
+		<div className="problem-panel-container" style={{backgroundColor}}>
+			<div
+				className={`problem-panel-header ${backgroundColor === '#ffffff' ? 'problem-panel-header-light' : 'problem-panel-header-dark'}`}
+			>
+				<span className="problem-panel-title">Problems</span>
+			</div>
+			<div className="problem-panel-content" style={{backgroundColor}}>
+				{problems.length === 0 ? (
+					<div className="problem-panel-empty-state">
+						<div className="problem-panel-empty-state-content">
+							<div className="problem-panel-empty-state-icon">✨</div>
+							<div
+								className="problem-panel-empty-state-text"
+								style={{color: textColor}}
+							>
+								No problems detected
+							</div>
+						</div>
+					</div>
+				) : (
+					<div className="problem-panel-problems-list">
+						{problems.map(problem => (
+							<div
+								key={problem.id}
+								className={`problem-panel-problem-item ${
+									backgroundColor === '#ffffff'
+										? 'problem-panel-problem-item-light'
+										: 'problem-panel-problem-item-dark'
+								} ${
+									problem.type === 'error'
+										? 'problem-panel-problem-item-error'
+										: problem.type === 'warning'
+											? 'problem-panel-problem-item-warning'
+											: 'problem-panel-problem-item-info'
+								}`}
+							>
+								<div className="problem-panel-problem-content">
+									<div className="problem-panel-problem-details">
+										<div className="problem-panel-problem-meta">
+											<div className="problem-panel-problem-tags">
+												<span
+													className="problem-panel-problem-type-badge"
+													style={{color: textColor}}
+												>
+													{problem.type.toUpperCase()}
+												</span>
+												{problem.source && (
+													<span
+														className="problem-panel-problem-source"
+														style={{color: textColor}}
+													>
+														{problem.source}
+													</span>
+												)}
+												{(problem.line || problem.column) && (
+													<span
+														className="problem-panel-problem-location"
+														style={{color: textColor}}
+													>
+														{problem.line && `Line ${problem.line}`}
+														{problem.line && problem.column && ':'}
+														{problem.column && `Col ${problem.column}`}
+													</span>
+												)}
+											</div>
+											<span
+												className="problem-panel-problem-timestamp"
+												style={{color: textColor}}
+											>
+												{formatTimestamp(problem.timestamp)}
+											</span>
+										</div>
+
+										<div className="problem-panel-problem-message-container">
+											<p
+												className="problem-panel-problem-message"
+												style={{color: textColor}}
+											>
+												{problem.message}
+											</p>
+										</div>
+									</div>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
 };
 
-export default ProblemPanel; 
+export default ProblemPanel;


### PR DESCRIPTION
# fix(ui): apply theme text color to problem panel badge

# Closes #662

This PR fixes an issue where the problem type badge text in the Problem Panel did not adapt to the active theme, resulting in poor readability in dark mode.

### Changes
- Applied theme-based `textColor` to the problem panel badge text
- Ensured consistent text contrast in both light and dark modes

### Flags
- UI-only change
- No functional or behavioral impact
- No breaking changes

### Screenshots or Video
**Before:**
<img width="1948" height="344" alt="image" src="https://github.com/user-attachments/assets/1fdbd26e-3bf3-4b93-894b-77bd483ecf0f" />

**After:**
<img width="1948" height="344" alt="image" src="https://github.com/user-attachments/assets/6dfb4cee-103a-418a-9826-19042a9f70f9" />

### Related Issues
- Issue #662 

### Author Checklist
- [x] Ensure you provide a DCO sign-off using the `--signoff` option of git commit
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commit messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`