### PR TITLE
fix: apply theme color to problem panel badge

### DIFF
--- a/src/components/ProblemPanel.tsx
+++ b/src/components/ProblemPanel.tsx
@@ -110,7 +110,7 @@ const ProblemPanel: React.FC = () => {
                   <div className="problem-panel-problem-details">
                     <div className="problem-panel-problem-meta">
                       <div className="problem-panel-problem-tags">
-                        <span className="problem-panel-problem-type-badge">
+                        <span className="problem-panel-problem-type-badge" style={{ color: textColor }}>
                           {problem.type.toUpperCase()}
                         </span>
                         {problem.source && (


### PR DESCRIPTION
# fix(ui): apply theme text color to problem panel badge

# Closes #662

This PR fixes an issue where the problem type badge text in the Problem Panel did not adapt to the active theme, resulting in poor readability in dark mode.

### Changes
- Applied theme-based `textColor` to the problem panel badge text
- Ensured consistent text contrast in both light and dark modes

### Flags
- UI-only change
- No functional or behavioral impact
- No breaking changes

### Screenshots or Video
**Before:**
<img width="1948" height="344" alt="image" src="https://github.com/user-attachments/assets/1fdbd26e-3bf3-4b93-894b-77bd483ecf0f" />

**After:**
<img width="1948" height="344" alt="image" src="https://github.com/user-attachments/assets/6dfb4cee-103a-418a-9826-19042a9f70f9" />

### Related Issues
- Issue #662 

### Author Checklist
- [x] Ensure you provide a DCO sign-off using the `--signoff` option of git commit
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commit messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`