### PR TITLE
fix: improve TemplateMarkdown toolbar contrast in dark mode (#670)

### DIFF
--- a/src/components/TemplateMarkdownToolbar.tsx
+++ b/src/components/TemplateMarkdownToolbar.tsx
@@ -1,15 +1,23 @@
 import { LuHeading1, LuHeading2, LuHeading3 } from "react-icons/lu";
-import { FaBold, FaItalic, FaLink, FaImage, FaListUl, FaListOl } from "react-icons/fa";
+import {
+  FaBold,
+  FaItalic,
+  FaLink,
+  FaImage,
+  FaListUl,
+  FaListOl,
+} from "react-icons/fa";
 import { useMarkdownEditorContext } from "../contexts/MarkdownEditorContext";
 
 export const TemplateMarkdownToolbar = () => {
   const { commands: markdownEditorCommands } = useMarkdownEditorContext();
+  const buttonClassName = "markdown-toolbar-button border-none bg-transparent";
 
   return (
     <div className="markdown-toolbar">
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.toggleHeading1?.()}
         title="Heading 1"
       >
@@ -17,7 +25,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.toggleHeading2?.()}
         title="Heading 2"
       >
@@ -25,7 +33,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.toggleHeading3?.()}
         title="Heading 3"
       >
@@ -33,7 +41,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="markdown-toolbar-button border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.toggleBold?.()}
         title="Bold"
       >
@@ -41,7 +49,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.toggleItalic?.()}
         title="Italic"
       >
@@ -49,7 +57,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.toggleUnorderedList?.()}
         title="Unordered list"
       >
@@ -57,7 +65,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.toggleOrderedList?.()}
         title="Ordered list"
       >
@@ -65,7 +73,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.insertLink?.()}
         title="Insert link"
       >
@@ -73,7 +81,7 @@ export const TemplateMarkdownToolbar = () => {
       </button>
       <button
         type="button"
-        className="border-none bg-transparent hover:bg-slate-200"
+        className={buttonClassName}
         onClick={() => markdownEditorCommands?.insertImage?.()}
         title="Insert image"
       >
@@ -82,5 +90,3 @@ export const TemplateMarkdownToolbar = () => {
     </div>
   );
 };
-
-

--- a/src/index.css
+++ b/src/index.css
@@ -12,23 +12,39 @@ body {
 }
 
 html[data-theme="dark"] {
-    --bg-color: #121212;
-    --text-color: #ffffff;
-    --border-color: #444444;
-    --active-bg-color: #333333;
-    --active-text-color: #ffffff; 
-    --hover-bg-color: #444444;
-    --hover-text-color: #ffffff;
-    background-color: #121212;
+  --bg-color: #121212;
+  --text-color: #ffffff;
+  --border-color: #444444;
+  --active-bg-color: #333333;
+  --active-text-color: #ffffff;
+  --hover-bg-color: #444444;
+  --hover-text-color: #ffffff;
+  background-color: #121212;
 }
 
 html[data-theme="light"] {
-    --bg-color: #ffffff;
-    --text-color: #121212;
-    --border-color: #ddd;
-    --active-bg-color: #e0e0e0;
-    --active-text-color: #1b2540; 
-    --hover-bg-color: #e0e0e0;
-    --hover-text-color: #050c40;
-    background-color: #ffffff;
+  --bg-color: #ffffff;
+  --text-color: #121212;
+  --border-color: #ddd;
+  --active-bg-color: #e0e0e0;
+  --active-text-color: #1b2540;
+  --hover-bg-color: #e0e0e0;
+  --hover-text-color: #050c40;
+  background-color: #ffffff;
+}
+
+html[data-theme="light"] .markdown-toolbar-button {
+  color: #000000;
+}
+
+html[data-theme="light"] .markdown-toolbar-button:hover {
+  background-color: #d5dce2;
+}
+
+html[data-theme="dark"] .markdown-toolbar-button {
+  color: #ffffff;
+}
+
+html[data-theme="dark"] .markdown-toolbar-button:hover {
+  background-color: #5d6167;
 }


### PR DESCRIPTION
# fix: improve TemplateMarkdown toolbar contrast in dark mode (#670)

Closes #670

### Changes
- Update TemplateMarkdown toolbar buttons to use theme-based color styles
- Add light/dark mode CSS rules for toolbar button text and hover backgrounds

### Flags
- Uses html[data-theme] selectors to align with existing theme system
- No functional changes beyond styling

### Related Issues
- Issue #670

### Author Checklist
- [ ] Ensure you provide a DCO sign-off (use `git commit --signoff`)
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow AP format
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:fix-670-template-toolbar-dark`