### PR TITLE
Add automatic screenshot capture on test failures

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,5 +1,15 @@
 import { test, expect } from '@playwright/test';
 
+test.afterEach(async ({ page }, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus) {
+    await page.screenshot({
+      path: `screenshots/${testInfo.title.replace(/\s+/g, '_')}.png`,
+      fullPage: true,
+    });
+  }
+});
+
+
 test.describe('App Loading', () => {
   test('should load the app and display main components', async ({ page }) => {
     await page.goto('/');


### PR DESCRIPTION
This PR adds automatic screenshot capture when Playwright tests fail.

Screenshots are saved in the `screenshots/` directory to help with
debugging and identifying UI issues more easily.

This improves test reliability and makes failure investigation faster.
