### PR TITLE
fix: Remove debug console.log in AnthropicProvider stream handler

### DIFF
--- a/src/ai-assistant/llmProviders.ts
+++ b/src/ai-assistant/llmProviders.ts
@@ -126,7 +126,6 @@ export class AnthropicProvider extends LLMProvider {
 
       const stream = client.messages.stream(params);
       stream.on('text', (textDelta) => {
-        console.log(textDelta)
         onChunk(textDelta);
       });
 


### PR DESCRIPTION
#### Fixes: N/A
### Problem:
The `AnthropicProvider.streamChat()` method in `llmProviders.ts` uses `console.log(textDelta)` to output every streamed AI response chunk during chat sessions. This causes:
- **Console spam**: Every token from the AI response is logged individually, flooding the browser console
- **Privacy concern**: Conversation content is exposed in dev tools
- **Inconsistency**: No other provider (OpenAI, Google, Ollama, etc) has this logging. its clearly a leftover debug statement.

### Solution:
 Remove `console.log(textDelta)` on line 129. The `onChunk(textDelta)` callback already handles the data correctly.

### Changes:
Just a one-line change. 

- `src/ai-assistant/llmProviders.ts:` Removed debug `console.log(textDelta)` from `AnthropicProvider.streamChat()`