### PR TITLE
feat: add font size and word wrap settings to editor preferences

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { Modal, Switch, Collapse, Space, Divider, Typography } from 'antd';
+import { Modal, Switch, Collapse, Space, Divider, Typography, Select } from 'antd';
 import { BulbOutlined, MoonOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons';
 import useAppStore from '../store/store';
 import AIConfigSection from './AIConfigSection';
+import { FONT_SIZE_OPTIONS } from '../constants/editorSettings';
 
 const { Text } = Typography;
 
@@ -12,6 +13,10 @@ const SettingsModal: React.FC = () => {
     setSettingsOpen, 
     showLineNumbers, 
     setShowLineNumbers,
+    editorFontSize,
+    setEditorFontSize,
+    editorWordWrap,
+    setEditorWordWrap,
     backgroundColor,
     toggleDarkMode
   } = useAppStore((state) => ({
@@ -19,6 +24,10 @@ const SettingsModal: React.FC = () => {
     setSettingsOpen: state.setSettingsOpen,
     showLineNumbers: state.showLineNumbers,
     setShowLineNumbers: state.setShowLineNumbers,
+    editorFontSize: state.editorFontSize,
+    setEditorFontSize: state.setEditorFontSize,
+    editorWordWrap: state.editorWordWrap,
+    setEditorWordWrap: state.setEditorWordWrap,
     backgroundColor: state.backgroundColor,
     toggleDarkMode: state.toggleDarkMode,
   }));
@@ -69,6 +78,45 @@ const SettingsModal: React.FC = () => {
               checked={showLineNumbers}
               onChange={setShowLineNumbers}
               aria-label="Toggle line numbers"
+            />
+          </div>
+
+          <Divider style={{ margin: 0 }} />
+
+          {/* Font Size Dropdown */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <div style={{ flex: 1 }}>
+              <Text strong style={{ display: 'block' }}>Font Size</Text>
+              <Text type="secondary" style={{ fontSize: 13 }}>
+                Adjust font size in code editors
+              </Text>
+            </div>
+            <Select
+              value={editorFontSize}
+              onChange={setEditorFontSize}
+              style={{ width: 80 }}
+              aria-label="Editor font size"
+              options={FONT_SIZE_OPTIONS.map((size) => ({
+                value: size,
+                label: `${size}px`,
+              }))}
+            />
+          </div>
+
+          <Divider style={{ margin: 0 }} />
+
+          {/* Word Wrap Toggle */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <div style={{ flex: 1 }}>
+              <Text strong style={{ display: 'block' }}>Word Wrap</Text>
+              <Text type="secondary" style={{ fontSize: 13 }}>
+                Wrap long lines in code editors
+              </Text>
+            </div>
+            <Switch
+              checked={editorWordWrap}
+              onChange={setEditorWordWrap}
+              aria-label="Toggle word wrap"
             />
           </div>
         </Space>

--- a/src/constants/editorSettings.ts
+++ b/src/constants/editorSettings.ts
@@ -1,0 +1,2 @@
+export const FONT_SIZE_OPTIONS = [12, 13, 14, 15, 16, 18, 20] as const;
+export const DEFAULT_FONT_SIZE = 14;

--- a/src/editors/ConcertoEditor.tsx
+++ b/src/editors/ConcertoEditor.tsx
@@ -138,7 +138,7 @@ export default function ConcertoEditor({
 
   const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
     minimap: { enabled: false },
-    wordWrap: editorWordWrap ? "on" : "off",
+    wordWrap: editorWordWrap ? "on" as const : "off" as const,
     automaticLayout: true,
     scrollBeyondLastLine: false,
     fontSize: editorFontSize,

--- a/src/editors/ConcertoEditor.tsx
+++ b/src/editors/ConcertoEditor.tsx
@@ -125,10 +125,12 @@ export default function ConcertoEditor({
 }: ConcertoEditorProps) {
   const { handleSelection, MenuComponent } = useCodeSelection("concerto");
   const monacoInstance = useMonaco();
-  const { error, aiConfig, showLineNumbers } = useAppStore((state) => ({
+  const { error, aiConfig, showLineNumbers, editorFontSize, editorWordWrap } = useAppStore((state) => ({
     error: state.error,
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
+    editorFontSize: state.editorFontSize,
+    editorWordWrap: state.editorWordWrap,
   }));
   const ctoErr = error?.startsWith("c:") ? error : undefined;
 
@@ -136,9 +138,10 @@ export default function ConcertoEditor({
 
   const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
     minimap: { enabled: false },
-    wordWrap: "on",
+    wordWrap: editorWordWrap ? "on" : "off",
     automaticLayout: true,
     scrollBeyondLastLine: false,
+    fontSize: editorFontSize,
     lineNumbers: showLineNumbers ? 'on' : 'off',
     autoClosingBrackets: "languageDefined",
     autoSurround: "languageDefined",
@@ -159,7 +162,7 @@ export default function ConcertoEditor({
     acceptSuggestionOnCommitCharacter: false,
     acceptSuggestionOnEnter: "off",
     tabCompletion: "off",
-  }), [aiConfig?.enableInlineSuggestions, showLineNumbers]);
+  }), [aiConfig?.enableInlineSuggestions, showLineNumbers, editorFontSize, editorWordWrap]);
 
   const handleEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
     if (editorRef) {

--- a/src/editors/JSONEditor.tsx
+++ b/src/editors/JSONEditor.tsx
@@ -32,7 +32,7 @@ export default function JSONEditor({
 
   const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
     minimap: { enabled: false },
-    wordWrap: editorWordWrap ? "on" : "off",
+    wordWrap: editorWordWrap ? "on" as const : "off" as const,
     automaticLayout: true,
     scrollBeyondLastLine: false,
     fontSize: editorFontSize,

--- a/src/editors/JSONEditor.tsx
+++ b/src/editors/JSONEditor.tsx
@@ -21,18 +21,21 @@ export default function JSONEditor({
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("json");
 
-  const { aiConfig, showLineNumbers } = useAppStore((state) => ({
+  const { aiConfig, showLineNumbers, editorFontSize, editorWordWrap } = useAppStore((state) => ({
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
+    editorFontSize: state.editorFontSize,
+    editorWordWrap: state.editorWordWrap,
   }));
 
   const themeName = useThemeName();
 
   const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
     minimap: { enabled: false },
-    wordWrap: "on",
+    wordWrap: editorWordWrap ? "on" : "off",
     automaticLayout: true,
     scrollBeyondLastLine: false,
+    fontSize: editorFontSize,
     lineNumbers: showLineNumbers ? 'on' : 'off',
     inlineSuggest: {
       enabled: aiConfig?.enableInlineSuggestions !== false,
@@ -50,7 +53,7 @@ export default function JSONEditor({
     acceptSuggestionOnCommitCharacter: false,
     acceptSuggestionOnEnter: "off",
     tabCompletion: "off",
-  }), [aiConfig?.enableInlineSuggestions, showLineNumbers]);
+  }), [aiConfig?.enableInlineSuggestions, showLineNumbers, editorFontSize, editorWordWrap]);
 
 
   const handleEditorWillMount = (monacoInstance: typeof monaco) => {

--- a/src/editors/MarkdownEditor.tsx
+++ b/src/editors/MarkdownEditor.tsx
@@ -24,11 +24,13 @@ export default function MarkdownEditor({
   editorRef?: MutableRefObject<editor.IStandaloneCodeEditor | null>;
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("markdown");
-  const { backgroundColor, textColor, aiConfig, showLineNumbers } = useAppStore((state) => ({
+  const { backgroundColor, textColor, aiConfig, showLineNumbers, editorFontSize, editorWordWrap } = useAppStore((state) => ({
     backgroundColor: state.backgroundColor,
     textColor: state.textColor,
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
+    editorFontSize: state.editorFontSize,
+    editorWordWrap: state.editorWordWrap,
   }));
   const monaco = useMonaco();
 
@@ -59,9 +61,10 @@ export default function MarkdownEditor({
 
   const editorOptions: editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
     minimap: { enabled: false },
-    wordWrap: "on" as const,
+    wordWrap: editorWordWrap ? "on" as const : "off" as const,
     automaticLayout: true,
     scrollBeyondLastLine: false,
+    fontSize: editorFontSize,
     lineNumbers: showLineNumbers ? 'on' : 'off',
     inlineSuggest: {
       enabled: aiConfig?.enableInlineSuggestions !== false,
@@ -79,7 +82,7 @@ export default function MarkdownEditor({
     acceptSuggestionOnCommitCharacter: false,
     acceptSuggestionOnEnter: "off",
     tabCompletion: "off",
-  }), [aiConfig?.enableInlineSuggestions, showLineNumbers]);
+  }), [aiConfig?.enableInlineSuggestions, showLineNumbers, editorFontSize, editorWordWrap]);
 
   const handleEditorDidMount = (editorInstance: editor.IStandaloneCodeEditor) => {
     if (editorRef) {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -6,6 +6,7 @@ import { ModelManager } from "@accordproject/concerto-core";
 import { TemplateMarkInterpreter } from "@accordproject/template-engine";
 import { TemplateMarkTransformer } from "@accordproject/markdown-template";
 import { transform } from "@accordproject/markdown-transform";
+import { FONT_SIZE_OPTIONS, DEFAULT_FONT_SIZE } from "../constants/editorSettings";
 import { SAMPLES, Sample } from "../samples";
 import * as playground from "../samples/playground";
 import { compress, decompress } from "../utils/compression/compression";
@@ -62,6 +63,10 @@ interface AppState {
   toggleDataCollapse: () => void;
   showLineNumbers: boolean;
   setShowLineNumbers: (value: boolean) => void;
+  editorFontSize: number;
+  setEditorFontSize: (value: number) => void;
+  editorWordWrap: boolean;
+  setEditorWordWrap: (value: boolean) => void;
   isSettingsOpen: boolean;
   setSettingsOpen: (value: boolean) => void;
   keyProtectionLevel: KeyProtectionLevel | null;
@@ -81,7 +86,7 @@ async function rebuild(template: string, model: string, dataString: string): Pro
   // Validate inputs before expensive operations
   // This fails fast on invalid JSON or CTO syntax without running network calls
   await validateBeforeRebuild(template, model, dataString);
-  
+
   // @ts-expect-error `offline` is supported at runtime but not yet in published typings
   const modelManager = new ModelManager({ strict: true, offline: true });
   modelManager.addCTOModel(model, undefined, true);
@@ -165,6 +170,27 @@ const getInitialLineNumbers = () => {
   return true; // Default to showing line numbers
 };
 
+const getInitialFontSize = () => {
+  if (typeof window !== 'undefined') {
+    const saved = localStorage.getItem('editorFontSize');
+    if (saved !== null) {
+      const parsed = parseInt(saved, 10);
+      if (!isNaN(parsed) && (FONT_SIZE_OPTIONS as readonly number[]).includes(parsed)) return parsed;
+    }
+  }
+  return DEFAULT_FONT_SIZE;
+};
+
+const getInitialWordWrap = () => {
+  if (typeof window !== 'undefined') {
+    const saved = localStorage.getItem('editorWordWrap');
+    if (saved !== null) {
+      return saved === 'true';
+    }
+  }
+  return true; // Default to word wrap on
+};
+
 const useAppStore = create<AppState>()(
   immer(
     devtools((set, get) => {
@@ -199,6 +225,8 @@ const useAppStore = create<AppState>()(
         isTemplateCollapsed: false,
         isDataCollapsed: false,
         showLineNumbers: getInitialLineNumbers(),
+        editorFontSize: getInitialFontSize(),
+        editorWordWrap: getInitialWordWrap(),
         isSettingsOpen: false,
         keyProtectionLevel: null,
         toggleModelCollapse: () => set((state) => ({ isModelCollapsed: !state.isModelCollapsed })),
@@ -209,6 +237,19 @@ const useAppStore = create<AppState>()(
             localStorage.setItem('showLineNumbers', String(value));
           }
           set({ showLineNumbers: value });
+        },
+        setEditorFontSize: (value: number) => {
+          if (!FONT_SIZE_OPTIONS.includes(value as typeof FONT_SIZE_OPTIONS[number])) return;
+          if (typeof window !== 'undefined') {
+            localStorage.setItem('editorFontSize', String(value));
+          }
+          set({ editorFontSize: value });
+        },
+        setEditorWordWrap: (value: boolean) => {
+          if (typeof window !== 'undefined') {
+            localStorage.setItem('editorWordWrap', String(value));
+          }
+          set({ editorWordWrap: value });
         },
         setSettingsOpen: (value: boolean) => set({ isSettingsOpen: value }),
         setEditorsVisible: (value) => {

--- a/src/tests/components/SettingsModal.test.tsx
+++ b/src/tests/components/SettingsModal.test.tsx
@@ -4,6 +4,9 @@ import '@testing-library/jest-dom';
 import SettingsModal from '../../components/SettingsModal';
 
 // Mock the store - use inline functions to avoid hoisting issues
+const mockSetEditorFontSize = vi.fn();
+const mockSetEditorWordWrap = vi.fn();
+
 vi.mock('../../store/store', () => {
   return {
     default: vi.fn((selector) => selector({
@@ -12,9 +15,9 @@ vi.mock('../../store/store', () => {
       showLineNumbers: true,
       setShowLineNumbers: vi.fn(),
       editorFontSize: 14,
-      setEditorFontSize: vi.fn(),
+      setEditorFontSize: mockSetEditorFontSize,
       editorWordWrap: true,
-      setEditorWordWrap: vi.fn(),
+      setEditorWordWrap: mockSetEditorWordWrap,
       textColor: '#121212',
       backgroundColor: '#ffffff',
       toggleDarkMode: vi.fn(),
@@ -103,6 +106,14 @@ describe('SettingsModal', () => {
     expect(toggle).toBeChecked();
   });
 
+  it('calls setEditorWordWrap when word wrap toggle is clicked', () => {
+    render(<SettingsModal />);
+    
+    const toggle = screen.getByRole('switch', { name: /toggle word wrap/i });
+    fireEvent.click(toggle);
+    expect(mockSetEditorWordWrap).toHaveBeenCalledWith(false, expect.anything());
+  });
+
   it('renders divider between settings', () => {
     render(<SettingsModal />);
     
@@ -143,4 +154,3 @@ describe('SettingsModal', () => {
     expect(screen.getByText('AI Configuration Content')).toBeInTheDocument();
   });
 });
-

--- a/src/tests/components/SettingsModal.test.tsx
+++ b/src/tests/components/SettingsModal.test.tsx
@@ -11,6 +11,10 @@ vi.mock('../../store/store', () => {
       setSettingsOpen: vi.fn(),
       showLineNumbers: true,
       setShowLineNumbers: vi.fn(),
+      editorFontSize: 14,
+      setEditorFontSize: vi.fn(),
+      editorWordWrap: true,
+      setEditorWordWrap: vi.fn(),
       textColor: '#121212',
       backgroundColor: '#ffffff',
       toggleDarkMode: vi.fn(),
@@ -71,6 +75,34 @@ describe('SettingsModal', () => {
     expect(toggle).toBeChecked();
   });
 
+  it('renders the Font Size setting', () => {
+    render(<SettingsModal />);
+    
+    expect(screen.getByText('Font Size')).toBeInTheDocument();
+    expect(screen.getByText('Adjust font size in code editors')).toBeInTheDocument();
+  });
+
+  it('renders the Word Wrap setting', () => {
+    render(<SettingsModal />);
+    
+    expect(screen.getByText('Word Wrap')).toBeInTheDocument();
+    expect(screen.getByText('Wrap long lines in code editors')).toBeInTheDocument();
+  });
+
+  it('renders the word wrap toggle switch', () => {
+    render(<SettingsModal />);
+    
+    const toggle = screen.getByRole('switch', { name: /toggle word wrap/i });
+    expect(toggle).toBeInTheDocument();
+  });
+
+  it('word wrap toggle is checked when editorWordWrap is true', () => {
+    render(<SettingsModal />);
+    
+    const toggle = screen.getByRole('switch', { name: /toggle word wrap/i });
+    expect(toggle).toBeChecked();
+  });
+
   it('renders divider between settings', () => {
     render(<SettingsModal />);
     
@@ -111,3 +143,4 @@ describe('SettingsModal', () => {
     expect(screen.getByText('AI Configuration Content')).toBeInTheDocument();
   });
 });
+

--- a/src/tests/store/editorFontSize.test.tsx
+++ b/src/tests/store/editorFontSize.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import useAppStore from '../../store/store';
+
+describe('useAppStore - editorFontSize', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAppStore.setState({
+      editorFontSize: 14,
+    });
+  });
+
+  it('should have editorFontSize default to 14', () => {
+    const state = useAppStore.getState();
+    expect(state.editorFontSize).toBe(14);
+  });
+
+  it('should update editorFontSize when setEditorFontSize is called', () => {
+    const store = useAppStore.getState();
+    
+    store.setEditorFontSize(18);
+    
+    expect(useAppStore.getState().editorFontSize).toBe(18);
+  });
+
+  it('should persist editorFontSize to localStorage', () => {
+    const store = useAppStore.getState();
+    
+    store.setEditorFontSize(16);
+    
+    expect(localStorage.getItem('editorFontSize')).toBe('16');
+  });
+
+  it('should set various font sizes correctly', () => {
+    const store = useAppStore.getState();
+    
+    store.setEditorFontSize(12);
+    expect(useAppStore.getState().editorFontSize).toBe(12);
+    
+    store.setEditorFontSize(20);
+    expect(useAppStore.getState().editorFontSize).toBe(20);
+    
+    store.setEditorFontSize(14);
+    expect(useAppStore.getState().editorFontSize).toBe(14);
+  });
+});

--- a/src/tests/store/editorFontSize.test.tsx
+++ b/src/tests/store/editorFontSize.test.tsx
@@ -9,7 +9,7 @@ describe('useAppStore - editorFontSize', () => {
     });
   });
 
-  it('should have editorFontSize default to 14', () => {
+  it('should have editorFontSize set to 14 after reset', () => {
     const state = useAppStore.getState();
     expect(state.editorFontSize).toBe(14);
   });
@@ -30,7 +30,7 @@ describe('useAppStore - editorFontSize', () => {
     expect(localStorage.getItem('editorFontSize')).toBe('16');
   });
 
-  it('should set various font sizes correctly', () => {
+  it('should set various valid font sizes correctly', () => {
     const store = useAppStore.getState();
     
     store.setEditorFontSize(12);
@@ -40,6 +40,16 @@ describe('useAppStore - editorFontSize', () => {
     expect(useAppStore.getState().editorFontSize).toBe(20);
     
     store.setEditorFontSize(14);
+    expect(useAppStore.getState().editorFontSize).toBe(14);
+  });
+
+  it('should reject font sizes outside the allowed options', () => {
+    const store = useAppStore.getState();
+
+    store.setEditorFontSize(5);
+    expect(useAppStore.getState().editorFontSize).toBe(14);
+
+    store.setEditorFontSize(100);
     expect(useAppStore.getState().editorFontSize).toBe(14);
   });
 });

--- a/src/tests/store/editorFontSize.test.tsx
+++ b/src/tests/store/editorFontSize.test.tsx
@@ -46,10 +46,15 @@ describe('useAppStore - editorFontSize', () => {
   it('should reject font sizes outside the allowed options', () => {
     const store = useAppStore.getState();
 
+    // Start from a non-default valid size
+    store.setEditorFontSize(18);
+    expect(useAppStore.getState().editorFontSize).toBe(18);
+
+    // Invalid sizes should not change the current font size
     store.setEditorFontSize(5);
-    expect(useAppStore.getState().editorFontSize).toBe(14);
+    expect(useAppStore.getState().editorFontSize).toBe(18);
 
     store.setEditorFontSize(100);
-    expect(useAppStore.getState().editorFontSize).toBe(14);
+    expect(useAppStore.getState().editorFontSize).toBe(18);
   });
 });

--- a/src/tests/store/editorWordWrap.test.tsx
+++ b/src/tests/store/editorWordWrap.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import useAppStore from '../../store/store';
+
+describe('useAppStore - editorWordWrap', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAppStore.setState({
+      editorWordWrap: true,
+    });
+  });
+
+  it('should have editorWordWrap default to true', () => {
+    const state = useAppStore.getState();
+    expect(state.editorWordWrap).toBe(true);
+  });
+
+  it('should update editorWordWrap when setEditorWordWrap is called', () => {
+    const store = useAppStore.getState();
+    
+    store.setEditorWordWrap(false);
+    
+    expect(useAppStore.getState().editorWordWrap).toBe(false);
+  });
+
+  it('should persist editorWordWrap to localStorage', () => {
+    const store = useAppStore.getState();
+    
+    store.setEditorWordWrap(false);
+    
+    expect(localStorage.getItem('editorWordWrap')).toBe('false');
+  });
+
+  it('should toggle editorWordWrap correctly', () => {
+    const store = useAppStore.getState();
+    
+    // Initially true
+    expect(useAppStore.getState().editorWordWrap).toBe(true);
+    
+    // Set to false
+    store.setEditorWordWrap(false);
+    expect(useAppStore.getState().editorWordWrap).toBe(false);
+    
+    // Set back to true
+    store.setEditorWordWrap(true);
+    expect(useAppStore.getState().editorWordWrap).toBe(true);
+  });
+});

--- a/src/tests/store/editorWordWrap.test.tsx
+++ b/src/tests/store/editorWordWrap.test.tsx
@@ -9,7 +9,7 @@ describe('useAppStore - editorWordWrap', () => {
     });
   });
 
-  it('should have editorWordWrap default to true', () => {
+  it('should have editorWordWrap set to true after reset', () => {
     const state = useAppStore.getState();
     expect(state.editorWordWrap).toBe(true);
   });


### PR DESCRIPTION
# Closes #720

Add **Font Size** (dropdown) and **Word Wrap** (toggle) settings to the Settings modal, applying to all three Monaco code editors with localStorage persistence.

### Changes

- Add `editorFontSize` (number, default 14) and `editorWordWrap` (boolean, default true) state to the Zustand store with localStorage persistence
- Add Font Size `<Select>` dropdown (12–20px) and Word Wrap `<Switch>` toggle to the Settings modal
- Update all three editors (MarkdownEditor, ConcertoEditor, JSONEditor) to consume `fontSize` and `wordWrap` from the store
- Add new store unit tests for `editorFontSize` and `editorWordWrap`
- Update [SettingsModal.test.tsx](cci:7://file:///home/shubhraj/OpenSource/playground/src/tests/components/SettingsModal.test.tsx:0:0-0:0) with 4 new tests for the added UI elements

### Flags

- No new dependencies introduced — uses existing `antd` `Select` and `Switch` components
- Follows the exact same pattern as the existing `showLineNumbers` setting for consistency

### Screenshots or Video

[Screencast from 2026-02-19 20-11-31.webm](https://github.com/user-attachments/assets/f1d718a3-30df-4ef1-a8bd-6f1673f27935)


### Related Issues

- Issue #720

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`