### PR TITLE
fix(ui): standardize GitHub casing in header

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -384,7 +384,7 @@ function Navbar() {
             <GithubOutlined className={`text-xl text-white ${
               screens.md ? "mr-1.5" : "mr-0"
             }`} />
-            <span className={screens.md ? "inline" : "hidden"}>Github</span>
+            <span className={screens.md ? "inline" : "hidden"}>GitHub</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
# Closes #N/A

This pull request standardizes the casing of the word **GitHub** in header to ensure brand consistency and improve visual polish.

### Changes
- Updated label text from `Github` to `GitHub`
- Corrected casing in `Navbar.tsx` 

### Flags
- No functional changes
- UI-only text update

### Screenshots or Video
- Not applicable (minor text-only change)

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests (not required for text-only change)
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary