### PR TITLE
Feature Reqquest - Add Font Size and Word Wrap settings to editor pre…

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
-import { Modal, Switch } from 'antd';
+import { Modal, Switch, Select } from 'antd';
 import DarkModeToggle from 'react-dark-mode-toggle';
 import useAppStore from '../store/store';
 
+const FONT_SIZES = [12, 13, 14, 15, 16, 18, 20];
+
 const SettingsModal: React.FC = () => {
-  const { 
-    isSettingsOpen, 
-    setSettingsOpen, 
-    showLineNumbers, 
+  const {
+    isSettingsOpen,
+    setSettingsOpen,
+    showLineNumbers,
     setShowLineNumbers,
     textColor,
     backgroundColor,
-    toggleDarkMode
+    toggleDarkMode,
+    editorSettings,
+    setEditorSettings,
   } = useAppStore((state) => ({
     isSettingsOpen: state.isSettingsOpen,
     setSettingsOpen: state.setSettingsOpen,
@@ -20,6 +24,8 @@ const SettingsModal: React.FC = () => {
     textColor: state.textColor,
     backgroundColor: state.backgroundColor,
     toggleDarkMode: state.toggleDarkMode,
+    editorSettings: state.editorSettings,
+    setEditorSettings: state.setEditorSettings,
   }));
 
   const isDarkMode = backgroundColor === '#121212';
@@ -35,7 +41,8 @@ const SettingsModal: React.FC = () => {
       style={{ maxWidth: 480 }}
     >
       <div className="space-y-6 py-4">
-        {/* Dark Mode Toggle */}
+
+        {/* Dark Mode */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div className="flex-1 min-w-0">
             <h4 className="font-medium text-sm sm:text-base" style={{ color: textColor }}>
@@ -45,18 +52,12 @@ const SettingsModal: React.FC = () => {
               Toggle between light and dark theme
             </p>
           </div>
-          <div className="flex-shrink-0">
-            <DarkModeToggle
-              onChange={toggleDarkMode}
-              checked={isDarkMode}
-              size={50}
-            />
-          </div>
+          <DarkModeToggle onChange={toggleDarkMode} checked={isDarkMode} size={50} />
         </div>
 
         <hr className={isDarkMode ? 'border-gray-600' : 'border-gray-200'} />
 
-        {/* Line Numbers Toggle */}
+        {/* Line Numbers */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div className="flex-1 min-w-0">
             <h4 className="font-medium text-sm sm:text-base" style={{ color: textColor }}>
@@ -66,14 +67,53 @@ const SettingsModal: React.FC = () => {
               Display line numbers in code editors
             </p>
           </div>
-          <div className="flex-shrink-0">
-            <Switch
-              checked={showLineNumbers}
-              onChange={setShowLineNumbers}
-              aria-label="Toggle line numbers"
-            />
-          </div>
+          <Switch checked={showLineNumbers} onChange={setShowLineNumbers} />
         </div>
+
+        <hr className={isDarkMode ? 'border-gray-600' : 'border-gray-200'} />
+
+        {/* Font Size */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <h4 className="font-medium text-sm sm:text-base" style={{ color: textColor }}>
+              Font Size
+            </h4>
+            <p className={`text-xs sm:text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+              Adjust editor font size
+            </p>
+          </div>
+          <Select
+            value={editorSettings.fontSize}
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            onChange={(value) => setEditorSettings({ fontSize: value })}
+            style={{ width: 110 }}
+            options={FONT_SIZES.map((size) => ({
+              label: `${size}px`,
+              value: size,
+            }))}
+          />
+        </div>
+
+        <hr className={isDarkMode ? 'border-gray-600' : 'border-gray-200'} />
+
+        {/* Word Wrap */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div className="flex-1 min-w-0">
+            <h4 className="font-medium text-sm sm:text-base" style={{ color: textColor }}>
+              Word Wrap
+            </h4>
+            <p className={`text-xs sm:text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+              Wrap long lines in editors
+            </p>
+          </div>
+          <Switch
+            checked={editorSettings.wordWrap === 'on'}
+            onChange={(checked) =>
+              setEditorSettings({ wordWrap: checked ? 'on' : 'off' })
+            }
+          />
+        </div>
+
       </div>
     </Modal>
   );

--- a/src/editors/ConcertoEditor.tsx
+++ b/src/editors/ConcertoEditor.tsx
@@ -24,7 +24,6 @@ const concertoKeywords = [
   "enum",
   "scalar",
   "extends",
-  "default",
   "participant",
   "asset",
   "o",
@@ -60,22 +59,21 @@ const handleEditorWillMount = (monacoInstance: typeof monaco) => {
       { open: "{", close: "}" },
       { open: "[", close: "]" },
       { open: "(", close: ")" },
-      { open: "\"", close: "\"" },
+      { open: `"`, close: `"` },
     ],
     surroundingPairs: [
       { open: "{", close: "}" },
       { open: "[", close: "]" },
       { open: "(", close: ")" },
-      { open: "\"", close: "\"" },
+      { open: `"`, close: `"` },
     ],
   });
 
   monacoInstance.languages.setMonarchTokensProvider("concerto", {
     keywords: concertoKeywords,
     typeKeywords: concertoTypes,
-    operators: ["=", "{", "}", "@", '"'],
+    operators: ["=", "{", "}", "@", `"`],
     symbols: /[=}{@"]+/,
-    escapes: /\\(?:[btnfru"'\\]|\\u[0-9A-Fa-f]{4})/,
     tokenizer: {
       root: [
         { include: "@whitespace" },
@@ -89,12 +87,11 @@ const handleEditorWillMount = (monacoInstance: typeof monaco) => {
             },
           },
         ],
-        [/"([^"\\]|\\.)*$/, "string.invalid"], // non-terminated string
+        [/"([^"\\]|\\.)*$/, "string.invalid"],
         [/"/, "string", "@string"],
       ],
       string: [
         [/[^\\"]+/, "string"],
-        [/@escapes/, "string.escape"],
         [/\\./, "string.escape.invalid"],
         [/"/, "string", "@pop"],
       ],
@@ -105,9 +102,7 @@ const handleEditorWillMount = (monacoInstance: typeof monaco) => {
     },
   });
 
-  if (monacoInstance) {
-    registerAutocompletion('concerto', monacoInstance);
-  }
+  registerAutocompletion("concerto", monacoInstance);
 };
 
 interface ConcertoEditorProps {
@@ -115,53 +110,77 @@ interface ConcertoEditorProps {
   onChange?: (value: string | undefined) => void;
 }
 
-export default function ConcertoEditor({
-  value,
-  onChange,
-}: ConcertoEditorProps) {
+export default function ConcertoEditor({ value, onChange }: ConcertoEditorProps) {
   const { handleSelection, MenuComponent } = useCodeSelection("concerto");
   const monacoInstance = useMonaco();
-  const { error, backgroundColor, aiConfig, showLineNumbers } = useAppStore((state) => ({
+
+  const {
+    error,
+    backgroundColor,
+    aiConfig,
+    showLineNumbers,
+    editorSettings,
+  } = useAppStore((state) => ({
     error: state.error,
     backgroundColor: state.backgroundColor,
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
+    editorSettings: state.editorSettings,
   }));
+
   const ctoErr = error?.startsWith("c:") ? error : undefined;
 
   const themeName = useMemo(
-    () => (backgroundColor ? "darkTheme" : "lightTheme"),
+    () => (backgroundColor === "#121212" ? "darkTheme" : "lightTheme"),
     [backgroundColor]
   );
 
-  const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
-    minimap: { enabled: false },
-    wordWrap: "on",
-    automaticLayout: true,
-    scrollBeyondLastLine: false,
-    lineNumbers: showLineNumbers ? 'on' : 'off',
-    autoClosingBrackets: "languageDefined",
-    autoSurround: "languageDefined",
-    bracketPairColorization: { enabled: true },
-    inlineSuggest: {
-      enabled: aiConfig?.enableInlineSuggestions !== false,
-      mode: "prefix",
-      suppressSuggestions: false,
-      fontFamily: "inherit",
-      keepOnBlur: true,
-    },
-    suggest: {
-      preview: true,
-      showInlineDetails: true,
-    },
-    quickSuggestions: false,
-    suggestOnTriggerCharacters: false,
-    acceptSuggestionOnCommitCharacter: false,
-    acceptSuggestionOnEnter: "off",
-    tabCompletion: "off",
-  }), [aiConfig?.enableInlineSuggestions, showLineNumbers]);
+  const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(
+    () => ({
+      minimap: { enabled: false },
+      automaticLayout: true,
+      scrollBeyondLastLine: false,
 
-  const handleEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
+      // 🔑 NEW — editor settings
+      fontSize: editorSettings.fontSize,
+      wordWrap: editorSettings.wordWrap,
+
+      lineNumbers: showLineNumbers ? "on" : "off",
+
+      autoClosingBrackets: "languageDefined",
+      autoSurround: "languageDefined",
+      bracketPairColorization: { enabled: true },
+
+      inlineSuggest: {
+        enabled: aiConfig?.enableInlineSuggestions !== false,
+        mode: "prefix",
+        suppressSuggestions: false,
+        fontFamily: "inherit",
+        keepOnBlur: true,
+      },
+
+      suggest: {
+        preview: true,
+        showInlineDetails: true,
+      },
+
+      quickSuggestions: false,
+      suggestOnTriggerCharacters: false,
+      acceptSuggestionOnCommitCharacter: false,
+      acceptSuggestionOnEnter: "off",
+      tabCompletion: "off",
+    }),
+    [
+      aiConfig?.enableInlineSuggestions,
+      showLineNumbers,
+      editorSettings.fontSize,
+      editorSettings.wordWrap,
+    ]
+  );
+
+  const handleEditorDidMount = (
+    editor: monaco.editor.IStandaloneCodeEditor
+  ) => {
     editor.onDidChangeCursorSelection(() => {
       handleSelection(editor);
     });
@@ -169,7 +188,7 @@ export default function ConcertoEditor({
 
   const handleChange = useCallback(
     (val: string | undefined) => {
-      if (onChange) onChange(val);
+      onChange?.(val);
     },
     [onChange]
   );
@@ -183,8 +202,9 @@ export default function ConcertoEditor({
     if (ctoErr) {
       const match = ctoErr.match(/Line (\d+) column (\d+)/);
       if (match) {
-        const lineNumber = parseInt(match[1], 10);
-        const columnNumber = parseInt(match[2], 10);
+        const lineNumber = Number(match[1]);
+        const columnNumber = Number(match[2]);
+
         monacoInstance.editor.setModelMarkers(model, "customMarker", [
           {
             startLineNumber: lineNumber,

--- a/src/editors/JSONEditor.tsx
+++ b/src/editors/JSONEditor.tsx
@@ -18,53 +18,72 @@ export default function JSONEditor({
   editorRef?: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>;
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("json");
-  
-  const { backgroundColor, aiConfig, showLineNumbers } = useAppStore((state) => ({
+
+  const {
+    backgroundColor,
+    aiConfig,
+    showLineNumbers,
+    editorSettings,
+  } = useAppStore((state) => ({
     backgroundColor: state.backgroundColor,
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
+    editorSettings: state.editorSettings,
   }));
 
   const themeName = useMemo(
-    () => (backgroundColor ? "darkTheme" : "lightTheme"),
+    () => (backgroundColor === "#121212" ? "darkTheme" : "lightTheme"),
     [backgroundColor]
   );
 
-  const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
-    minimap: { enabled: false },
-    wordWrap: "on",
-    automaticLayout: true,
-    scrollBeyondLastLine: false,
-    lineNumbers: showLineNumbers ? 'on' : 'off',
-    inlineSuggest: {
-      enabled: aiConfig?.enableInlineSuggestions !== false,
-      mode: "prefix",
-      suppressSuggestions: false,
-      fontFamily: "inherit",
-      keepOnBlur: true,
-    },
-    suggest: {
-      preview: true,
-      showInlineDetails: true,
-    },
-    quickSuggestions: false,
-    suggestOnTriggerCharacters: false,
-    acceptSuggestionOnCommitCharacter: false,
-    acceptSuggestionOnEnter: "off",
-    tabCompletion: "off",
-  }), [aiConfig?.enableInlineSuggestions, showLineNumbers]);
+  const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(
+    () => ({
+      minimap: { enabled: false },
+      automaticLayout: true,
+      scrollBeyondLastLine: false,
 
+      // 🔑 NEW — editor settings
+      fontSize: editorSettings.fontSize,
+      wordWrap: editorSettings.wordWrap,
+
+      lineNumbers: showLineNumbers ? "on" : "off",
+
+      inlineSuggest: {
+        enabled: aiConfig?.enableInlineSuggestions !== false,
+        mode: "prefix",
+        suppressSuggestions: false,
+        fontFamily: "inherit",
+        keepOnBlur: true,
+      },
+      suggest: {
+        preview: true,
+        showInlineDetails: true,
+      },
+      quickSuggestions: false,
+      suggestOnTriggerCharacters: false,
+      acceptSuggestionOnCommitCharacter: false,
+      acceptSuggestionOnEnter: "off",
+      tabCompletion: "off",
+    }),
+    [
+      aiConfig?.enableInlineSuggestions,
+      showLineNumbers,
+      editorSettings.fontSize,
+      editorSettings.wordWrap,
+    ]
+  );
 
   const handleEditorWillMount = (monacoInstance: typeof monaco) => {
-    if (monacoInstance) {
-      registerAutocompletion('json', monacoInstance);
-    }
+    registerAutocompletion("json", monacoInstance);
   };
 
-  const handleEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
+  const handleEditorDidMount = (
+    editor: monaco.editor.IStandaloneCodeEditor
+  ) => {
     if (editorRef) {
       editorRef.current = editor;
     }
+
     editor.onDidChangeCursorSelection(() => {
       handleSelection(editor);
     });
@@ -72,7 +91,7 @@ export default function JSONEditor({
 
   const handleChange = useCallback(
     (val: string | undefined) => {
-      if (onChange) onChange(val);
+      onChange?.(val);
     },
     [onChange]
   );

--- a/src/editors/MarkdownEditor.tsx
+++ b/src/editors/MarkdownEditor.tsx
@@ -5,7 +5,6 @@ import { useCodeSelection } from "../components/CodeSelectionMenu";
 import type { editor } from "monaco-editor";
 import { registerAutocompletion } from "../ai-assistant/autocompletion";
 
-
 const MonacoEditor = lazy(() =>
   import("@monaco-editor/react").then((mod) => ({ default: mod.Editor }))
 );
@@ -20,65 +19,87 @@ export default function MarkdownEditor({
   onEditorReady?: (editor: editor.IStandaloneCodeEditor) => void;
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("markdown");
-  const { backgroundColor, textColor, aiConfig, showLineNumbers } = useAppStore((state) => ({
+
+  const {
+    backgroundColor,
+    textColor,
+    aiConfig,
+    showLineNumbers,
+    editorSettings,
+  } = useAppStore((state) => ({
     backgroundColor: state.backgroundColor,
     textColor: state.textColor,
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
+    editorSettings: state.editorSettings,
   }));
+
   const monaco = useMonaco();
 
   const themeName = useMemo(
-    () => (backgroundColor ? "darkTheme" : "lightTheme"),
+    () => (backgroundColor === "#121212" ? "darkTheme" : "lightTheme"),
     [backgroundColor]
   );
 
   useEffect(() => {
-    if (monaco) {
-      const defineTheme = (name: string, base: "vs" | "vs-dark") => {
-        monaco.editor.defineTheme(name, {
-          base,
-          inherit: true,
-          rules: [],
-          colors: {
-            "editor.background": backgroundColor,
-            "editor.foreground": textColor,
-            "editor.lineHighlightBorder": "#EDE8DC",
-            "editorGhostText.foreground": "#9c9a9a"
-          },
-        });
-      };
+    if (!monaco) return;
 
-      defineTheme("lightTheme", "vs");
-      defineTheme("darkTheme", "vs-dark");
+    const defineTheme = (name: string, base: "vs" | "vs-dark") => {
+      monaco.editor.defineTheme(name, {
+        base,
+        inherit: true,
+        rules: [],
+        colors: {
+          "editor.background": backgroundColor,
+          "editor.foreground": textColor,
+          "editor.lineHighlightBorder": "#EDE8DC",
+          "editorGhostText.foreground": "#9c9a9a",
+        },
+      });
+    };
 
-      monaco.editor.setTheme(themeName);
-    }
+    defineTheme("lightTheme", "vs");
+    defineTheme("darkTheme", "vs-dark");
+
+    monaco.editor.setTheme(themeName);
   }, [monaco, backgroundColor, textColor, themeName]);
 
-  const editorOptions: editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
-    minimap: { enabled: false },
-    wordWrap: "on" as const,
-    automaticLayout: true,
-    scrollBeyondLastLine: false,
-    lineNumbers: showLineNumbers ? 'on' : 'off',
-    inlineSuggest: {
-      enabled: aiConfig?.enableInlineSuggestions !== false,
-      mode: "prefix",
-      suppressSuggestions: false,
-      fontFamily: "inherit",
-      keepOnBlur: true,
-    },
-    suggest: {
-      preview: true,
-      showInlineDetails: true,
-    },
-    quickSuggestions: false,
-    suggestOnTriggerCharacters: false,
-    acceptSuggestionOnCommitCharacter: false,
-    acceptSuggestionOnEnter: "off",
-    tabCompletion: "off",
-  }), [aiConfig?.enableInlineSuggestions, showLineNumbers]);
+  const editorOptions: editor.IStandaloneEditorConstructionOptions = useMemo(
+    () => ({
+      minimap: { enabled: false },
+      automaticLayout: true,
+      scrollBeyondLastLine: false,
+
+      // 🔑 NEW — editor settings
+      fontSize: editorSettings.fontSize,
+      wordWrap: editorSettings.wordWrap,
+
+      lineNumbers: showLineNumbers ? "on" : "off",
+
+      inlineSuggest: {
+        enabled: aiConfig?.enableInlineSuggestions !== false,
+        mode: "prefix",
+        suppressSuggestions: false,
+        fontFamily: "inherit",
+        keepOnBlur: true,
+      },
+      suggest: {
+        preview: true,
+        showInlineDetails: true,
+      },
+      quickSuggestions: false,
+      suggestOnTriggerCharacters: false,
+      acceptSuggestionOnCommitCharacter: false,
+      acceptSuggestionOnEnter: "off",
+      tabCompletion: "off",
+    }),
+    [
+      aiConfig?.enableInlineSuggestions,
+      showLineNumbers,
+      editorSettings.fontSize,
+      editorSettings.wordWrap,
+    ]
+  );
 
   const handleEditorDidMount = (editorInstance: editor.IStandaloneCodeEditor) => {
     editorInstance.onDidChangeCursorSelection(() => {
@@ -86,17 +107,15 @@ export default function MarkdownEditor({
     });
 
     if (monaco) {
-      registerAutocompletion('markdown', monaco);
+      registerAutocompletion("markdown", monaco);
     }
 
-    if (onEditorReady) {
-      onEditorReady(editorInstance);
-    }
+    onEditorReady?.(editorInstance);
   };
 
   const handleChange = useCallback(
     (val: string | undefined) => {
-      if (onChange) onChange(val);
+      onChange?.(val);
     },
     [onChange]
   );

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -62,6 +62,13 @@ interface AppState {
   toggleTemplateCollapse: () => void;
   toggleDataCollapse: () => void;
   showLineNumbers: boolean;
+  editorSettings: {
+  fontSize: number;
+  wordWrap: 'on' | 'off';
+};
+setEditorSettings: (
+  partial: Partial<AppState['editorSettings']>
+) => void;
   setShowLineNumbers: (value: boolean) => void;
   isSettingsOpen: boolean;
   setSettingsOpen: (value: boolean) => void;
@@ -160,11 +167,43 @@ const getInitialLineNumbers = () => {
   return true; // Default to showing line numbers
 };
 
+const getInitialEditorSettings = () => {
+  const defaults = {
+    fontSize: 14,
+    wordWrap: 'on' as 'on' | 'off',
+  };
+
+  if (typeof window !== 'undefined') {
+    try {
+      const saved = localStorage.getItem('editor-settings');
+      if (saved) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return { ...defaults, ...(JSON.parse(saved)) };
+      }
+    } catch {
+      // ignore corrupted storage
+    }
+  }
+
+  return defaults;
+};
+
+const saveEditorSettings = (settings: {
+  fontSize: number;
+  wordWrap: 'on' | 'off';
+}) => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('editor-settings', JSON.stringify(settings));
+  }
+};
+
 const useAppStore = create<AppState>()(
   immer(
     devtools((set, get) => {
       const initialTheme = getInitialTheme();
       const initialPanels = getInitialPanelState(); // Load saved panels
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const initialEditorSettings = getInitialEditorSettings();
 
       return {
         backgroundColor: initialTheme.backgroundColor,
@@ -195,6 +234,8 @@ const useAppStore = create<AppState>()(
       isTemplateCollapsed: false,
       isDataCollapsed: false,
       showLineNumbers: getInitialLineNumbers(),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      editorSettings: initialEditorSettings,
       isSettingsOpen: false,
       toggleModelCollapse: () => set((state) => ({ isModelCollapsed: !state.isModelCollapsed })),
       toggleTemplateCollapse: () => set((state) => ({ isTemplateCollapsed: !state.isTemplateCollapsed })),
@@ -205,6 +246,16 @@ const useAppStore = create<AppState>()(
         }
         set({ showLineNumbers: value });
       },
+      setEditorSettings: (partial) => {
+  set((state) => {
+    const next = {
+      ...state.editorSettings,
+      ...partial,
+    };
+    saveEditorSettings(next);
+    state.editorSettings = next;
+  });
+},
       setSettingsOpen: (value: boolean) => set({ isSettingsOpen: value }),
       setEditorsVisible: (value) => {
         const state = get();


### PR DESCRIPTION
Add font size and word wrap settings to Playground editors

# Closes #<720>

This pull request adds configurable font size and word wrap options to the Playground’s code editors, improving accessibility and overall developer experience. Users can now adjust editor readability based on their screen size and personal preferences, and these settings persist across page reloads.

### Changes
- Added persistent editor settings for font size and word wrap in the global store.
- Extended the Settings modal with:
  - A font size dropdown (12px–20px, default 14px).
  - A word wrap toggle (enabled by default).
- Updated all three Monaco editors (Template Markdown, Concerto Model, JSON Data) to consume and apply the new settings consistently.

### Flags
- Editor settings are applied globally to all editors for consistency.
- No new dependencies were introduced; the implementation relies on native Monaco Editor options.

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests.
- [x] Commit messages follow AP format.
- [ ] Extend the documentation, if necessary.
- [x] Merging to `main` from `fork:feature-request`.