### PR TITLE
Encrypt AI API Keys using Web Crypto AES-GCM and add a security warning banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ const App = () => {
 
 
   const handleConfigSave = () => {
-    loadConfigFromLocalStorage();
+    void loadConfigFromLocalStorage();
     setAIConfigOpen(false);
   };
 

--- a/src/ai-assistant/chatRelay.ts
+++ b/src/ai-assistant/chatRelay.ts
@@ -4,13 +4,14 @@ import { prepareSystemPrompt } from "./prompts";
 import { getLLMProvider } from './llmProviders';
 import useAppStore from '../store/store';
 import { extractErrorMessage } from '../utils/helpers/errorUtils';
+import { retrieveApiKey } from '../utils/keyVault';
 
-export const loadConfigFromLocalStorage = () => {
+export const loadConfigFromLocalStorage = async () => {
   const setAIConfig = useAppStore.getState().setAIConfig;
   
   const savedProvider = localStorage.getItem('aiProvider');
   const savedModel = localStorage.getItem('aiModel');
-  const savedApiKey = localStorage.getItem('aiApiKey');
+  const savedApiKey = await retrieveApiKey();
   const savedCustomEndpoint = localStorage.getItem('aiCustomEndpoint');
   const savedMaxTokens = localStorage.getItem('aiResMaxTokens');
   
@@ -299,4 +300,4 @@ export const sendMessage = async (
   }
 };
 
-loadConfigFromLocalStorage();
+void loadConfigFromLocalStorage();

--- a/src/components/AIConfigPopup.tsx
+++ b/src/components/AIConfigPopup.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { AIConfigPopupProps } from '../types/components/AIAssistant.types';
 import useAppStore from '../store/store';
+import { storeApiKey, retrieveApiKey, removeApiKey } from '../utils/keyVault';
 
 const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
   const { backgroundColor } = useAppStore((state) => ({
@@ -58,32 +59,35 @@ const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
 
   useEffect(() => {
     if (isOpen) {
-      const savedProvider = localStorage.getItem('aiProvider');
-      const savedModel = localStorage.getItem('aiModel');
-      const savedApiKey = localStorage.getItem('aiApiKey');
-      const savedCustomEndpoint = localStorage.getItem('aiCustomEndpoint');
-      const savedMaxTokens = localStorage.getItem('aiResMaxTokens');
-      
-      const savedShowFullPrompt = localStorage.getItem('aiShowFullPrompt') === 'true';
-      const savedEnableCodeSelection = localStorage.getItem('aiEnableCodeSelectionMenu') !== 'false';
-      const savedEnableInlineSuggestions = localStorage.getItem('aiEnableInlineSuggestions') !== 'false';
-      
-      if (savedProvider) setProvider(savedProvider);
-      if (savedModel) setModel(savedModel);
-      if (savedApiKey) setApiKey(savedApiKey);
-      if (savedCustomEndpoint) setCustomEndpoint(savedCustomEndpoint);
-      if (savedMaxTokens) setMaxTokens(savedMaxTokens);
-      
-      setShowFullPrompt(savedShowFullPrompt);
-      setEnableCodeSelectionMenu(savedEnableCodeSelection);
-      setEnableInlineSuggestions(savedEnableInlineSuggestions);
+      const loadConfig = async () => {
+        const savedProvider = localStorage.getItem('aiProvider');
+        const savedModel = localStorage.getItem('aiModel');
+        const savedApiKey = await retrieveApiKey();
+        const savedCustomEndpoint = localStorage.getItem('aiCustomEndpoint');
+        const savedMaxTokens = localStorage.getItem('aiResMaxTokens');
+        
+        const savedShowFullPrompt = localStorage.getItem('aiShowFullPrompt') === 'true';
+        const savedEnableCodeSelection = localStorage.getItem('aiEnableCodeSelectionMenu') !== 'false';
+        const savedEnableInlineSuggestions = localStorage.getItem('aiEnableInlineSuggestions') !== 'false';
+        
+        if (savedProvider) setProvider(savedProvider);
+        if (savedModel) setModel(savedModel);
+        if (savedApiKey) setApiKey(savedApiKey);
+        if (savedCustomEndpoint) setCustomEndpoint(savedCustomEndpoint);
+        if (savedMaxTokens) setMaxTokens(savedMaxTokens);
+        
+        setShowFullPrompt(savedShowFullPrompt);
+        setEnableCodeSelectionMenu(savedEnableCodeSelection);
+        setEnableInlineSuggestions(savedEnableInlineSuggestions);
+      };
+      void loadConfig();
     }
   }, [isOpen]);
 
-  const handleSave = () => {
+  const handleSave = async () => {
     localStorage.setItem('aiProvider', provider);
     localStorage.setItem('aiModel', model);
-    localStorage.setItem('aiApiKey', apiKey);
+    await storeApiKey(apiKey);
     
     if (provider === 'openai-compatible') {
       localStorage.setItem('aiCustomEndpoint', customEndpoint);
@@ -114,7 +118,7 @@ const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
       // Clear all AI-related localStorage items
       localStorage.removeItem('aiProvider');
       localStorage.removeItem('aiModel');
-      localStorage.removeItem('aiApiKey');
+      removeApiKey();
       localStorage.removeItem('aiCustomEndpoint');
       localStorage.removeItem('aiResMaxTokens');
       localStorage.removeItem('aiShowFullPrompt');
@@ -246,6 +250,19 @@ const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
               placeholder="Enter API key"
               className={`w-full p-2 border rounded-lg focus:outline-none focus:ring-2 ${theme.input}`}
             />
+            <div className={`mt-2 p-2 rounded text-xs flex items-start gap-1.5 ${
+              backgroundColor !== '#ffffff'
+                ? 'bg-yellow-900 bg-opacity-40 border border-yellow-700 text-yellow-200'
+                : 'bg-yellow-50 border border-yellow-200 text-yellow-800'
+            }`}>
+              <span className="flex-shrink-0">⚠️</span>
+              <span>
+                <strong>Security Notice:</strong> Your API key is stored encrypted in your
+                browser's local storage and sent directly to the AI provider from your browser.
+                Use a <strong>restricted API key with spending limits</strong>.
+                Do not use this on shared or public computers.
+              </span>
+            </div>
           </div>
 
           <div className={`border rounded-lg ${theme.advancedContainer}`}>
@@ -345,7 +362,7 @@ const AIConfigPopup = ({ isOpen, onClose, onSave }: AIConfigPopupProps) => {
           </div>
 
            <button
-            onClick={handleSave}
+            onClick={() => void handleSave()}
             disabled={!provider || !model || (provider !== 'ollama' && !apiKey) || (provider === 'openai-compatible' && !customEndpoint)}
             className={`w-full py-2 rounded-lg transition-colors disabled:cursor-not-allowed ${
               !provider || !model || (provider !== 'ollama' && !apiKey) || (provider === 'openai-compatible' && !customEndpoint)

--- a/src/tests/utils/keyVault/keyVault.test.ts
+++ b/src/tests/utils/keyVault/keyVault.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// jsdom doesn't have crypto.subtle — we need to mock it.
+// We create a simple encrypt/decrypt mock that mirrors the real API shape.
+const mockEncrypt = vi.fn(async (_algo: unknown, _key: unknown, data: BufferSource) => {
+  // "Encrypt" by prepending a marker byte (0xFF) — enough to test the flow
+  const input = new Uint8Array(data as ArrayBuffer);
+  const output = new Uint8Array(input.length + 1);
+  output[0] = 0xff; // marker
+  output.set(input, 1);
+  return output.buffer;
+});
+
+const mockDecrypt = vi.fn(async (_algo: unknown, _key: unknown, data: BufferSource) => {
+  const input = new Uint8Array(data as ArrayBuffer);
+  // Strip the marker byte
+  return input.slice(1).buffer;
+});
+
+const mockDeriveKey = vi.fn(async () => ({ type: 'secret' }));
+const mockImportKey = vi.fn(async () => ({ type: 'raw' }));
+
+// Install the mock BEFORE importing keyVault
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    subtle: {
+      encrypt: mockEncrypt,
+      decrypt: mockDecrypt,
+      deriveKey: mockDeriveKey,
+      importKey: mockImportKey,
+    },
+    getRandomValues: (arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i++) arr[i] = i;
+      return arr;
+    },
+  },
+  writable: true,
+});
+
+// Now import the module under test
+import { storeApiKey, retrieveApiKey, removeApiKey } from '../../../utils/keyVault';
+
+describe('keyVault', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('storeApiKey encrypts and stores under aiApiKey_enc', async () => {
+    await storeApiKey('sk-test-key-123');
+
+    expect(localStorage.getItem('aiApiKey_enc')).not.toBeNull();
+    expect(localStorage.getItem('aiApiKey')).toBeNull(); // legacy key removed
+    // The stored value should be JSON with iv and data
+    const stored = JSON.parse(localStorage.getItem('aiApiKey_enc')!);
+    expect(stored).toHaveProperty('iv');
+    expect(stored).toHaveProperty('data');
+  });
+
+  it('retrieveApiKey decrypts the stored key', async () => {
+    await storeApiKey('sk-test-key-123');
+    const result = await retrieveApiKey();
+    expect(result).toBe('sk-test-key-123');
+  });
+
+  it('retrieveApiKey returns null when nothing is stored', async () => {
+    const result = await retrieveApiKey();
+    expect(result).toBeNull();
+  });
+
+  it('retrieveApiKey migrates a legacy plaintext key', async () => {
+    // Simulate a legacy plaintext key
+    localStorage.setItem('aiApiKey', 'sk-legacy-key');
+
+    const result = await retrieveApiKey();
+
+    // Should return the legacy key
+    expect(result).toBe('sk-legacy-key');
+    // Should have migrated to encrypted
+    expect(localStorage.getItem('aiApiKey_enc')).not.toBeNull();
+    // Legacy plaintext should be removed
+    expect(localStorage.getItem('aiApiKey')).toBeNull();
+  });
+
+  it('removeApiKey clears both encrypted and legacy keys', async () => {
+    await storeApiKey('sk-test-key-123');
+    localStorage.setItem('aiApiKey', 'sk-legacy'); // also set legacy
+
+    removeApiKey();
+
+    expect(localStorage.getItem('aiApiKey_enc')).toBeNull();
+    expect(localStorage.getItem('aiApiKey')).toBeNull();
+  });
+
+  it('storeApiKey then retrieveApiKey roundtrip works for various key formats', async () => {
+    const testKeys = [
+      'sk-proj-abc123XYZ',
+      'key-with-special/chars=+',
+      '', // empty string edge case
+      'a'.repeat(1000), // long key
+    ];
+
+    for (const key of testKeys) {
+      await storeApiKey(key);
+      const result = await retrieveApiKey();
+      expect(result).toBe(key);
+    }
+  });
+});

--- a/src/utils/keyVault.ts
+++ b/src/utils/keyVault.ts
@@ -1,0 +1,129 @@
+/**
+ * keyVault.ts — Encrypted storage for sensitive values (API keys).
+ *
+ * Uses the Web Crypto API (AES-GCM) to encrypt keys before writing them
+ * to localStorage, and decrypts on read.  This prevents casual extraction
+ * of API keys via DevTools → Application → Local Storage or by calling
+ * `localStorage.getItem()` in the console.
+ *
+ * Backward-compatible: if a legacy plaintext `aiApiKey` entry exists it is
+ * transparently migrated to the encrypted format on first read.
+ */
+
+const ENCRYPTED_STORAGE_KEY = "aiApiKey_enc";
+const LEGACY_STORAGE_KEY = "aiApiKey";
+
+// Fixed salt — acceptable here because the goal is obfuscation, not
+// protection against an attacker who already has arbitrary JS execution.
+const SALT = new Uint8Array([
+  0x74, 0x70, 0x6c, 0x61, 0x79, 0x67, 0x72, 0x6f, 0x75, 0x6e, 0x64, 0x5f, 0x73,
+  0x61, 0x6c, 0x74,
+]);
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function deriveKey(): Promise<CryptoKey> {
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(window.location.origin),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: SALT,
+      iterations: 100_000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+async function encrypt(plaintext: string): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey();
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+
+  return JSON.stringify({
+    iv: Array.from(iv),
+    data: Array.from(new Uint8Array(ciphertext)),
+  });
+}
+
+async function decrypt(payload: string): Promise<string> {
+  const { iv, data } = JSON.parse(payload) as { iv: number[]; data: number[] };
+  const key = await deriveKey();
+  const plainBuffer = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: new Uint8Array(iv) },
+    key,
+    new Uint8Array(data),
+  );
+
+  return new TextDecoder().decode(plainBuffer);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Encrypt an API key and store it in localStorage.
+ * Also removes any legacy plaintext entry.
+ */
+export async function storeApiKey(apiKey: string): Promise<void> {
+  const encrypted = await encrypt(apiKey);
+  localStorage.setItem(ENCRYPTED_STORAGE_KEY, encrypted);
+  // Clean up legacy plaintext key if it exists
+  localStorage.removeItem(LEGACY_STORAGE_KEY);
+}
+
+/**
+ * Retrieve and decrypt the API key from localStorage.
+ *
+ * Falls back to reading a legacy plaintext `aiApiKey` entry and
+ * automatically migrates it to the encrypted format.
+ *
+ * Returns `null` if no key is stored.
+ */
+export async function retrieveApiKey(): Promise<string | null> {
+  // 1. Try the encrypted entry first
+  const encryptedPayload = localStorage.getItem(ENCRYPTED_STORAGE_KEY);
+  if (encryptedPayload) {
+    try {
+      return await decrypt(encryptedPayload);
+    } catch {
+      // Corrupted — remove and fall through
+      localStorage.removeItem(ENCRYPTED_STORAGE_KEY);
+    }
+  }
+
+  // 2. Fall back to legacy plaintext entry and migrate
+  const legacyKey = localStorage.getItem(LEGACY_STORAGE_KEY);
+  if (legacyKey) {
+    // Migrate: encrypt and store, then remove plaintext
+    await storeApiKey(legacyKey);
+    return legacyKey;
+  }
+
+  return null;
+}
+
+/**
+ * Remove all API key entries (encrypted + legacy plaintext).
+ */
+export function removeApiKey(): void {
+  localStorage.removeItem(ENCRYPTED_STORAGE_KEY);
+  localStorage.removeItem(LEGACY_STORAGE_KEY);
+}


### PR DESCRIPTION
# Closes #752
Encrypt AI API keys at rest in `localStorage` using the Web Crypto API (AES-GCM) and add a visible security warning banner in the AI Configuration popup. Previously, API keys for OpenAI, Anthropic, Google, Mistral, and OpenRouter were stored as plaintext strings, readable by any browser extension, XSS attack, or `localStorage.getItem('aiApiKey')` call in the console.

### Changes
- New `src/utils/keyVault.ts` — Web Crypto AES-GCM encrypt/decrypt utility with PBKDF2 key derivation (100k iterations, SHA-256). Exports `storeApiKey()`, `retrieveApiKey()`, and `removeApiKey()`.
- Backward-compatible migration — retrieveApiKey() automatically detects legacy plaintext `aiApiKey` entries, encrypts and migrates them to `aiApiKey_enc`, then removes the plaintext entry.
- Updated `AIConfigPopup.tsx` — Save, load, and reset now use the encrypted `keyVault` instead of raw `localStorage`. Added a dark-mode-aware Security Notice banner below the API Key input advising users to use restricted keys with spending limits.
- Updated `chatRelay.ts` — `loadConfigFromLocalStorage()` is now async and uses `retrieveApiKey()` for decryption on startup.
- Updated `App.tsx` — Handles the now-async `loadConfigFromLocalStorage()` call.
- New `src/tests/utils/keyVault/keyVault.test.ts` — 6 unit tests covering encrypt/decrypt roundtrip, null handling, legacy migration, `removeApiKey()`, and edge cases (empty strings, long keys, special characters).

### Flags
- `crypto.subtle` is not available in jsdom, so unit tests mock it. The actual AES-GCM encryption runs in real browsers.
- This is obfuscation, not full security — a dedicated attacker with arbitrary JS execution on the page can still reproduce the key derivation. The primary goal is preventing casual extraction (DevTools, extensions scanning `localStorage`, `getItem()` in console).
- API keys are still sent client-side to provider APIs via `dangerouslyAllowBrowser: true` in the OpenAI/Anthropic SDKs. A backend proxy would be needed to fully eliminate client-side key exposure (out of scope for this PR).

### Screenshots or Video
Warning while Adding Configurations:
<img width="1800" height="1130" alt="Screenshot 2026-02-26 at 1 10 03 PM" src="https://github.com/user-attachments/assets/5329dc1d-4941-4a8c-ba14-64a52e67ec06" />
Console while AI model is loaded:
<img width="1800" height="1130" alt="Screenshot 2026-02-26 at 1 14 44 PM" src="https://github.com/user-attachments/assets/b8e09655-0361-498a-a5b0-aa8b47f8309c" />

### Related Issues
- Issue #752
- Pull Request #753

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
