### PR TITLE
feat: Auto-generate sample JSON data from Concerto model

### DIFF
--- a/src/pages/MainContainer.tsx
+++ b/src/pages/MainContainer.tsx
@@ -13,7 +13,7 @@ import "../styles/pages/MainContainer.css";
 import html2pdf from "html2pdf.js";
 import { Button, message } from "antd";
 import * as monaco from "monaco-editor";
-import { MdFormatAlignLeft, MdChevronRight, MdExpandMore } from "react-icons/md";
+import { MdFormatAlignLeft, MdChevronRight, MdExpandMore, MdAutoFixHigh } from "react-icons/md";
 import DOMPurify from "dompurify";
 
 const MainContainer = () => {
@@ -85,6 +85,7 @@ const MainContainer = () => {
     toggleModelCollapse,
     toggleTemplateCollapse,
     toggleDataCollapse,
+    generateSampleDataFromModel,
   } = useAppStore((state) => ({
     isAIChatOpen: state.isAIChatOpen,
     isEditorsVisible: state.isEditorsVisible,
@@ -96,6 +97,7 @@ const MainContainer = () => {
     toggleModelCollapse: state.toggleModelCollapse,
     toggleTemplateCollapse: state.toggleTemplateCollapse,
     toggleDataCollapse: state.toggleDataCollapse,
+    generateSampleDataFromModel: state.generateSampleDataFromModel,
   }));
 
   // Calculate dynamic panel sizes based on collapse states
@@ -223,14 +225,28 @@ const MainContainer = () => {
                           </button>
                           <span>Data <span style={{ fontSize: '0.75em', opacity: 0.6, fontWeight: 400 }}>(JSON)</span></span>
                         </div>
-                        <button
-                          onClick={handleJsonFormat}
-                          className="px-1 pt-1 border-gray-300 bg-white hover:bg-gray-200 rounded shadow-md"
-                          disabled={!jsonEditorRef.current || isDataCollapsed}
-                          title="Format JSON"
-                        >
-                          <MdFormatAlignLeft size={16} />
-                        </button>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginLeft: 'auto' }}>
+                          <button
+                            onClick={handleJsonFormat}
+                            className="px-1 pt-1 border-gray-300 bg-white hover:bg-gray-200 rounded shadow-md"
+                            disabled={!jsonEditorRef.current || isDataCollapsed}
+                            title="Format JSON"
+                          >
+                            <MdFormatAlignLeft size={16} />
+                          </button>
+                          <button
+                            onClick={() => {
+                              void generateSampleDataFromModel().then(() => {
+                                void message.success('Sample data generated!');
+                              });
+                            }}
+                            className="px-1 pt-1 border-gray-300 bg-white hover:bg-gray-200 rounded shadow-md"
+                            disabled={isDataCollapsed}
+                            title="Auto-generate sample data from Concerto model"
+                          >
+                            <MdAutoFixHigh size={16} />
+                          </button>
+                        </div>
                       </div>
                       {!isDataCollapsed && (
                         <div className="main-container-editor-content" style={{ backgroundColor }}>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,6 +3,7 @@ import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 import { debounce } from "ts-debounce";
 import { ModelManager } from "@accordproject/concerto-core";
+import { generateSampleData } from "../utils/generateSampleData";
 import { TemplateMarkInterpreter } from "@accordproject/template-engine";
 import { TemplateMarkTransformer } from "@accordproject/markdown-template";
 import { transform } from "@accordproject/markdown-transform";
@@ -54,6 +55,7 @@ interface AppState {
   setPreviewVisible: (value: boolean) => void;
   setProblemPanelVisible: (value: boolean) => void;
   startTour: () => void;
+  generateSampleDataFromModel: () => Promise<void>;
   isModelCollapsed: boolean;
   isTemplateCollapsed: boolean;
   isDataCollapsed: boolean;
@@ -400,6 +402,22 @@ const useAppStore = create<AppState>()(
         },
         startTour: () => {
           console.log('Starting tour...');
+        },
+        generateSampleDataFromModel: async () => {
+          try {
+            const sampleData = await generateSampleData(get().modelCto);
+            set(() => ({
+              data: sampleData,
+              editorAgreementData: sampleData,
+              error: undefined,
+            }));
+            await get().rebuild();
+          } catch (error: unknown) {
+            set(() => ({
+              error: formatError(error),
+              isProblemPanelVisible: true,
+            }));
+          }
         },
       }
     })

--- a/src/tests/generateSampleData/generateSampleData.test.ts
+++ b/src/tests/generateSampleData/generateSampleData.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { generateSampleData } from '../../utils/generateSampleData';
+
+describe('generateSampleData', () => {
+    it('should generate sample data for a simple model with primitives', async () => {
+        const model = `namespace test@1.0.0
+
+@template
+concept SimpleModel {
+    o String name
+    o Integer age
+    o Boolean active
+}`;
+
+        const result = await generateSampleData(model);
+        const data = JSON.parse(result);
+
+        expect(data.$class).toBe('test@1.0.0.SimpleModel');
+        expect(typeof data.name).toBe('string');
+        expect(typeof data.age).toBe('number');
+        expect(typeof data.active).toBe('boolean');
+    });
+
+    it('should generate sample data with optional field excluded by default', async () => {
+        const model = `namespace test@1.0.0
+
+@template
+concept OptionalModel {
+    o String name
+    o Integer age optional
+    o String nickname optional
+}`;
+
+        const result = await generateSampleData(model);
+        const data = JSON.parse(result);
+
+        expect(data.$class).toBe('test@1.0.0.OptionalModel');
+        expect(typeof data.name).toBe('string');
+    });
+
+    it('should generate sample data with enum fields', async () => {
+        const model = `namespace test@1.0.0
+
+enum Color {
+    o RED
+    o GREEN
+    o BLUE
+}
+
+@template
+concept EnumModel {
+    o String name
+    o Color favoriteColor
+}`;
+
+        const result = await generateSampleData(model);
+        const data = JSON.parse(result);
+
+        expect(data.$class).toBe('test@1.0.0.EnumModel');
+        expect(['RED', 'GREEN', 'BLUE']).toContain(data.favoriteColor);
+    });
+
+    it('should throw an error when no @template concept is found', async () => {
+        const model = `namespace test@1.0.0
+
+concept NotATemplate {
+    o String name
+}`;
+
+        await expect(generateSampleData(model)).rejects.toThrow(
+            'No @template concept found in the model'
+        );
+    });
+
+    it('should generate sample data for a complex model with nested concepts', async () => {
+        const model = `namespace test@1.0.0
+
+concept Item {
+    o String sku
+    o Integer quantity
+    o Double price
+}
+
+@template
+concept Order {
+    o String customerName
+    o DateTime orderDate
+    o Item[] items
+}`;
+
+        const result = await generateSampleData(model);
+        const data = JSON.parse(result);
+
+        expect(data.$class).toBe('test@1.0.0.Order');
+        expect(typeof data.customerName).toBe('string');
+        expect(Array.isArray(data.items)).toBe(true);
+        expect(data.items.length).toBe(1);
+        expect(data.items[0].$class).toBe('test@1.0.0.Item');
+        expect(typeof data.items[0].sku).toBe('string');
+        expect(typeof data.items[0].quantity).toBe('number');
+        expect(typeof data.items[0].price).toBe('number');
+    });
+});

--- a/src/utils/generateSampleData.ts
+++ b/src/utils/generateSampleData.ts
@@ -1,0 +1,49 @@
+import { ModelManager, Factory, Serializer } from "@accordproject/concerto-core";
+
+/**
+ * Finds the @template-decorated concept in the model manager and uses
+ * concerto-core's Factory (with ValueGenerator internally) to generate
+ * sample instance data, then serializes it to JSON.
+ *
+ * @param modelCto - The Concerto model in CTO format
+ * @returns A JSON string with sample data conforming to the model
+ */
+export async function generateSampleData(modelCto: string): Promise<string> {
+    const modelManager = new ModelManager({ strict: true });
+    modelManager.addCTOModel(modelCto, undefined, true);
+    await modelManager.updateExternalModels();
+
+    // Find the @template concept
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const concepts = modelManager.getConceptDeclarations();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const templateConcept = concepts.find(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        (c: any) => c.getDecorator("template") !== null
+    );
+
+    if (!templateConcept) {
+        throw new Error(
+            "No @template concept found in the model. " +
+            "Please add the @template decorator to the main concept in your Concerto model."
+        );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const ns: string = templateConcept.getNamespace();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const name: string = templateConcept.getName();
+
+    // Use Factory with generate:'sample' — internally uses ValueGenerator + InstanceGenerator
+    const factory = new Factory(modelManager);
+    const resource = factory.newConcept(ns, name, undefined, {
+        generate: 'sample',
+        includeOptionalFields: false,
+    });
+
+    // Serialize to plain JSON using concerto-core's Serializer
+    const serializer = new Serializer(factory, modelManager);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const json = serializer.toJSON(resource);
+    return JSON.stringify(json, null, 2);
+}


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- Title: feat: auto-generate sample JSON data from Concerto model -->

# Closes #766
Added an  button to the JSON Data panel that auto-generates sample JSON from the current Concerto model, populating the data editor with well-typed placeholder values.

### Changes
- Added [src/utils/generateSampleData.ts](cci:7://file:///home/hkumar/gitProjects/template-playground/src/utils/generateSampleData.ts:0:0-0:0) utility that introspects Concerto models and generates typed sample data (String, Integer, Double, Boolean, DateTime, enums, nested concepts, arrays)
- Added [generateSampleDataFromModel()](cci:1://file:///home/hkumar/gitProjects/template-playground/src/store/store.ts:400:8-415:9) action to Zustand store in [src/store/store.ts](cci:7://file:///home/hkumar/gitProjects/template-playground/src/store/store.ts:0:0-0:0)
- Added generate button in JSON Data header in [src/pages/MainContainer.tsx](cci:7://file:///home/hkumar/gitProjects/template-playground/src/pages/MainContainer.tsx:0:0-0:0)
- Added Approx 9 unit tests in [src/tests/utils/generateSampleData/generateSampleData.test.ts](cci:7://file:///home/hkumar/gitProjects/template-playground/src/tests/utils/generateSampleData/generateSampleData.test.ts:0:0-0:0)

### Screenshots or Video

<img width="1919" height="1028" alt="Screenshot 2026-03-02 222628" src="https://github.com/user-attachments/assets/b6bc71ac-3e79-4307-b5e6-7369f1706511" />
<img width="1919" height="1025" alt="image" src="https://github.com/user-attachments/assets/68d3c92b-5c01-4155-899b-5f2e1f9b31bd" />
