### PR TITLE
Fix/keyboard accessibility

### DIFF
--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -400,7 +400,17 @@ export const AIChatPanel = () => {
               <span className="text-xs text-gray-600 mr-1" style={{color: textColor}}>Context:</span>
               {/* TemplateMark Button */}
               <div
+                role="button"
+                tabIndex={0}
+                aria-label="Toggle TemplateMark context"
+                aria-pressed={includeTemplateMarkContent}
                 onClick={() => handleTemplateMarkToggle(!includeTemplateMarkContent)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleTemplateMarkToggle(!includeTemplateMarkContent);
+                  }
+                }}
                 className={
                   `px-1 py-0.5 text-xs rounded-full flex items-center cursor-pointer border transition-colors
                   ${includeTemplateMarkContent
@@ -435,7 +445,17 @@ export const AIChatPanel = () => {
               </div>
               {/* Concerto Button */}
               <div
+                role="button"
+                tabIndex={0}
+                aria-label="Toggle Concerto context"
+                aria-pressed={includeConcertoModelContent}
                 onClick={() => handleConcertoModelToggle(!includeConcertoModelContent)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleConcertoModelToggle(!includeConcertoModelContent);
+                  }
+                }}
                 className={
                   `px-1 py-0.5 text-xs rounded-full flex items-center cursor-pointer border transition-colors
                   ${includeConcertoModelContent
@@ -470,7 +490,17 @@ export const AIChatPanel = () => {
               </div>
               {/* Data Button */}
               <div
+                role="button"
+                tabIndex={0}
+                aria-label="Toggle Data context"
+                aria-pressed={includeDataContent}
                 onClick={() => handleDataToggle(!includeDataContent)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleDataToggle(!includeDataContent);
+                  }
+                }}
                 className={
                   `px-1 py-0.5 text-xs rounded-full flex items-center cursor-pointer border transition-colors
                   ${includeDataContent

--- a/src/components/FullScreenModal.tsx
+++ b/src/components/FullScreenModal.tsx
@@ -38,8 +38,17 @@ const FullScreenModal: React.FC = () => {
     <>
       <MdFullscreen
         size={24}
+        role="button"
+        tabIndex={0}
+        aria-label="Open fullscreen preview"
         style={{ cursor: "pointer" }}
         onClick={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
       />
       <Modal
         title="Output"

--- a/src/components/PlaygroundSidebar.tsx
+++ b/src/components/PlaygroundSidebar.tsx
@@ -163,6 +163,12 @@ const PlaygroundSidebar = () => {
             aria-label={title}
             tabIndex={0}
             onClick={onClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick?.();
+              }
+            }}
             className={`group playground-sidebar-nav-item ${
               active ? 'playground-sidebar-nav-item-active' : 'playground-sidebar-nav-item-inactive'
             } tour-${title.toLowerCase().replace(' ', '-')}`}
@@ -188,6 +194,12 @@ const PlaygroundSidebar = () => {
             aria-label={title}
             tabIndex={0}
             onClick={onClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick();
+              }
+            }}
             className={`group playground-sidebar-nav-bottom-item tour-${title.toLowerCase().replace(' ', '-')}`}
           >
             <Icon size={18} />

--- a/src/tests/components/KeyboardAccessibility.test.tsx
+++ b/src/tests/components/KeyboardAccessibility.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import PlaygroundSidebar from "../../components/PlaygroundSidebar";
-import FullScreenModal from "../../components/FullScreenModal";
 import { vi } from "vitest";
 
 // Mock the store

--- a/src/tests/components/KeyboardAccessibility.test.tsx
+++ b/src/tests/components/KeyboardAccessibility.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import PlaygroundSidebar from "../../components/PlaygroundSidebar";
+import FullScreenModal from "../../components/FullScreenModal";
+import { vi } from "vitest";
+
+// Mock the store
+const mockSetEditorsVisible = vi.fn();
+const mockSetPreviewVisible = vi.fn();
+const mockSetProblemPanelVisible = vi.fn();
+const mockSetAIChatOpen = vi.fn();
+const mockSetSettingsOpen = vi.fn();
+
+vi.mock("../../store/store", () => ({
+  default: () => ({
+    isEditorsVisible: true,
+    isPreviewVisible: true,
+    isProblemPanelVisible: false,
+    isAIChatOpen: false,
+    setEditorsVisible: mockSetEditorsVisible,
+    setPreviewVisible: mockSetPreviewVisible,
+    setProblemPanelVisible: mockSetProblemPanelVisible,
+    setAIChatOpen: mockSetAIChatOpen,
+    setSettingsOpen: mockSetSettingsOpen,
+    generateShareableLink: vi.fn(() => "https://example.com"),
+    textColor: "#000000",
+    backgroundColor: "#ffffff",
+  }),
+}));
+
+vi.mock("../../components/Tour", () => ({
+  default: { start: vi.fn() },
+}));
+
+vi.mock("../../components/FullScreenModal", () => ({
+  default: () => <div data-testid="fullscreen-modal">FullScreen</div>,
+}));
+
+vi.mock("../../components/SettingsModal", () => ({
+  default: () => <div data-testid="settings-modal">Settings</div>,
+}));
+
+describe("Keyboard Accessibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("PlaygroundSidebar - Top Nav", () => {
+    it("activates Editor button on Enter key", () => {
+      render(<PlaygroundSidebar />);
+      const editorButton = screen.getByRole("button", { name: /Editor/i });
+      fireEvent.keyDown(editorButton, { key: "Enter" });
+      expect(mockSetEditorsVisible).toHaveBeenCalled();
+    });
+
+    it("activates Editor button on Space key", () => {
+      render(<PlaygroundSidebar />);
+      const editorButton = screen.getByRole("button", { name: /Editor/i });
+      fireEvent.keyDown(editorButton, { key: " " });
+      expect(mockSetEditorsVisible).toHaveBeenCalled();
+    });
+
+    it("does not activate Editor button on other keys", () => {
+      render(<PlaygroundSidebar />);
+      const editorButton = screen.getByRole("button", { name: /Editor/i });
+      fireEvent.keyDown(editorButton, { key: "Tab" });
+      expect(mockSetEditorsVisible).not.toHaveBeenCalled();
+    });
+
+    it("activates Preview button on Enter key", () => {
+      render(<PlaygroundSidebar />);
+      const previewButton = screen.getByRole("button", { name: /Preview/i });
+      fireEvent.keyDown(previewButton, { key: "Enter" });
+      expect(mockSetPreviewVisible).toHaveBeenCalled();
+    });
+
+    it("activates Problems button on Space key", () => {
+      render(<PlaygroundSidebar />);
+      const problemsButton = screen.getByRole("button", { name: /Problems/i });
+      fireEvent.keyDown(problemsButton, { key: " " });
+      expect(mockSetProblemPanelVisible).toHaveBeenCalled();
+    });
+
+    it("activates AI Assistant button on Enter key", () => {
+      render(<PlaygroundSidebar />);
+      const aiButton = screen.getByRole("button", { name: /AI Assistant/i });
+      fireEvent.keyDown(aiButton, { key: "Enter" });
+      expect(mockSetAIChatOpen).toHaveBeenCalled();
+    });
+  });
+
+  describe("PlaygroundSidebar - Bottom Nav", () => {
+    it("activates Share button on Enter key", () => {
+      render(<PlaygroundSidebar />);
+      const shareButton = screen.getByRole("button", { name: /Share/i });
+      fireEvent.keyDown(shareButton, { key: "Enter" });
+      // Share calls handleShare which is async, just verify no error
+      expect(shareButton).toBeInTheDocument();
+    });
+
+    it("activates Settings button on Space key", () => {
+      render(<PlaygroundSidebar />);
+      const settingsButton = screen.getByRole("button", { name: /Settings/i });
+      fireEvent.keyDown(settingsButton, { key: " " });
+      expect(mockSetSettingsOpen).toHaveBeenCalledWith(true);
+    });
+
+    it("activates Start Tour button on Enter key", () => {
+      render(<PlaygroundSidebar />);
+      const tourButton = screen.getByRole("button", { name: /Start Tour/i });
+      fireEvent.keyDown(tourButton, { key: "Enter" });
+      expect(tourButton).toBeInTheDocument();
+    });
+  });
+
+  describe("PlaygroundSidebar - focusability", () => {
+    it("all nav items have tabIndex=0 for keyboard focus", () => {
+      render(<PlaygroundSidebar />);
+      const buttons = screen.getAllByRole("button");
+      buttons.forEach((button) => {
+        expect(button).toHaveAttribute("tabindex", "0");
+      });
+    });
+  });
+});


### PR DESCRIPTION
feat(a11y): enable keyboard accessibility for sidebar, fullscreen, and chat controls

# Closes #<CORRESPONDING ISSUE NUMBER>

This PR improves keyboard accessibility across multiple interactive components in the Playground. 

Several UI controls were implemented using non-semantic `<div>` elements or raw icons with `onClick` handlers only. While they functioned correctly with mouse interaction, they were not fully accessible to keyboard users or assistive technologies.

This update ensures all interactive elements can be focused via `Tab` and activated using `Enter` or `Space`, improving overall WCAG alignment and usability.

---

## Changes

- Add `onKeyDown` handlers to PlaygroundSidebar navigation items to support `Enter` and `Space` activation
- Add `role="button"` and `tabIndex={0}` where necessary for semantic clarity
- Add `aria-label` to the fullscreen icon in `FullScreenModal`
- Add keyboard activation support to fullscreen trigger
- Add `role="button"`, `tabIndex={0}`, `aria-label`, and `aria-pressed` to AIChatPanel context toggles
- Ensure `preventDefault()` is used to avoid unintended scroll behavior when pressing Space

---

## Flags

- No visual changes introduced
- No business logic changes — accessibility-only enhancement
- Behavior remains identical for mouse users
- Manual keyboard testing performed (Tab, Enter, Space)

---

## Screenshots or Video

N/A – No visual UI changes.  
Functionality verified through keyboard navigation testing.

---

## Related Issues

- Issue #768 

---

## Author Checklist

- [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commit messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:<branchname>`