### PR TITLE
feat(aiconfig): added predefined ai models

### DIFF
--- a/src/ai-assistant/providerModels.ts
+++ b/src/ai-assistant/providerModels.ts
@@ -27,6 +27,11 @@ export const PROVIDER_MODELS: Record<string, ModelOption[]> = {
         { label: 'Claude Haiku 4.5', value: 'claude-haiku-4.5' },
     ],
     google: [
+        { label: 'Gemini 3.1 Pro', value: 'gemini-3.1-pro' },
+        { label: 'Gemini 3.1 Flash', value: 'gemini-3.1-flash' },
+        { label: 'Gemini 3 Pro', value: 'gemini-3-pro' },
+        { label: 'Gemini 3 Flash', value: 'gemini-3-flash' },
+
         { label: 'Gemini 2.5 Pro', value: 'gemini-2.5-pro' },
         { label: 'Gemini 2.5 Flash', value: 'gemini-2.5-flash' },
         { label: 'Gemini 2.0 Flash', value: 'gemini-2.0-flash' },

--- a/src/ai-assistant/providerModels.ts
+++ b/src/ai-assistant/providerModels.ts
@@ -1,0 +1,67 @@
+/**
+ * Curated list of popular models for each AI provider.
+ * Used to populate the model selection dropdown in AIConfigPopup.
+ */
+
+export interface ModelOption {
+    label: string;
+    value: string;
+}
+
+export const PROVIDER_MODELS: Record<string, ModelOption[]> = {
+    openai: [
+        { label: 'GPT-5.2', value: 'gpt-5.2' },
+        { label: 'GPT-5.2 Pro', value: 'gpt-5.2-pro' },
+        { label: 'GPT-5 Mini', value: 'gpt-5-mini' },
+        { label: 'GPT-5 Nano', value: 'gpt-5-nano' },
+        { label: 'o3', value: 'o3' },
+        { label: 'o3 Pro', value: 'o3-pro' },
+        { label: 'o4 Mini', value: 'o4-mini' },
+        { label: 'GPT-4.1', value: 'gpt-4.1' },
+        { label: 'GPT-4.1 Mini', value: 'gpt-4.1-mini' },
+        { label: 'GPT-4.1 Nano', value: 'gpt-4.1-nano' },
+    ],
+    anthropic: [
+        { label: 'Claude Opus 4.6', value: 'claude-opus-4.6' },
+        { label: 'Claude Sonnet 4.5', value: 'claude-sonnet-4.5' },
+        { label: 'Claude Haiku 4.5', value: 'claude-haiku-4.5' },
+    ],
+    google: [
+        { label: 'Gemini 2.5 Pro', value: 'gemini-2.5-pro' },
+        { label: 'Gemini 2.5 Flash', value: 'gemini-2.5-flash' },
+        { label: 'Gemini 2.0 Flash', value: 'gemini-2.0-flash' },
+        { label: 'Gemini 2.0 Flash Lite', value: 'gemini-2.0-flash-lite' },
+    ],
+    mistral: [
+        { label: 'Mistral Large', value: 'mistral-large-latest' },
+        { label: 'Mistral Medium', value: 'mistral-medium-latest' },
+        { label: 'Mistral Small', value: 'mistral-small-latest' },
+        { label: 'Codestral', value: 'codestral-latest' },
+    ],
+    openrouter: [
+        { label: 'OpenAI GPT-5.2', value: 'openai/gpt-5.2' },
+        { label: 'Anthropic Claude Opus 4.6', value: 'anthropic/claude-opus-4.6' },
+        { label: 'Google Gemini 2.5 Pro', value: 'google/gemini-2.5-pro' },
+        { label: 'Google Gemini 2.5 Flash', value: 'google/gemini-2.5-flash' },
+    ],
+    ollama: [
+        { label: 'LLaMA 3', value: 'llama3' },
+        { label: 'LLaMA 3.1', value: 'llama3.1' },
+        { label: 'LLaMA 3.2', value: 'llama3.2' },
+        { label: 'Mistral', value: 'mistral' },
+        { label: 'Mixtral', value: 'mixtral' },
+        { label: 'Code LLaMA', value: 'codellama' },
+        { label: 'Qwen 2.5', value: 'qwen2.5' },
+        { label: 'Qwen 2.5 (0.5B)', value: 'qwen2.5:0.5b' },
+        { label: 'TinyLLaMA', value: 'tinyllama' },
+        { label: 'Phi 3', value: 'phi3' },
+    ],
+};
+
+/**
+ * Returns the list of suggested models for a given provider.
+ * Returns an empty array for unknown or custom providers.
+ */
+export function getModelsForProvider(provider: string): ModelOption[] {
+    return PROVIDER_MODELS[provider] ?? [];
+}

--- a/src/components/AIConfigPopup.tsx
+++ b/src/components/AIConfigPopup.tsx
@@ -9,6 +9,7 @@ import {
   clearStoredKey,
 } from '../utils/secureKeyStorage';
 import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai";
+import { getModelsForProvider } from '../ai-assistant/providerModels';
 
 const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
   const { backgroundColor, keyProtectionLevel, setKeyProtectionLevel } = useAppStore((state) => ({
@@ -62,12 +63,27 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
   const [showAdvancedSettings, setShowAdvancedSettings] = useState<boolean>(false);
   const [maxTokens, setMaxTokens] = useState<string>('');
 
+  const [isCustomModel, setIsCustomModel] = useState<boolean>(false);
   const [showFullPrompt, setShowFullPrompt] = useState<boolean>(false);
   const [enableCodeSelectionMenu, setEnableCodeSelectionMenu] = useState<boolean>(true);
   const [enableInlineSuggestions, setEnableInlineSuggestions] = useState<boolean>(true);
   const [webauthnAvailable, setWebauthnAvailable] = useState<boolean>(false);
   const [isEncrypting, setIsEncrypting] = useState<boolean>(false);
   const [securityMessage, setSecurityMessage] = useState<string>('');
+
+  const [fetchedModels, setFetchedModels] = useState<string[]>([]);
+  const staticModels = useMemo(() => getModelsForProvider(provider), [provider]);
+
+  const combinedModels = useMemo(() => {
+    const models = [...staticModels];
+    const staticValues = new Set(staticModels.map(m => m.value));
+    for (const m of fetchedModels) {
+      if (!staticValues.has(m)) {
+        models.push({ label: m, value: m });
+      }
+    }
+    return models;
+  }, [staticModels, fetchedModels]);
 
   // Check WebAuthn PRF support on mount
   useEffect(() => {
@@ -86,7 +102,14 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
     const savedEnableInlineSuggestions = localStorage.getItem('aiEnableInlineSuggestions') !== 'false';
 
     if (savedProvider) setProvider(savedProvider);
-    if (savedModel) setModel(savedModel);
+    if (savedModel) {
+      setModel(savedModel);
+      // initially check if it's a known model (static list)
+      const models = getModelsForProvider(savedProvider ?? '');
+      const isKnown = models.some(m => m.value === savedModel);
+      setIsCustomModel(!isKnown && savedModel !== '');
+    }
+
     if (savedCustomEndpoint) setCustomEndpoint(savedCustomEndpoint);
     if (savedMaxTokens) setMaxTokens(savedMaxTokens);
 
@@ -117,7 +140,6 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
     }
   }, [setKeyProtectionLevel]);
 
-  const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [showApiKey, setShowApiKey] = useState<boolean>(false);
   const [debouncedApiKey] = useDebounce(apiKey, 1000);
 
@@ -129,7 +151,7 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
   }, [isOpen, loadConfig]);
 
   useEffect(() => {
-	setAvailableModels([]);
+    setFetchedModels([]);
     if (!provider || !debouncedApiKey) return;
 
     const controller = new AbortController();
@@ -139,55 +161,55 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
       try {
         switch (provider) {
           case 'openai':
-		  case 'openai-compatible':
-			if (!apiKey) return;
+          case 'openai-compatible':
+            if (!apiKey) return;
 
-			let endpoint = provider === 'openai-compatible' ? customEndpoint : 'https://api.openai.com/v1';
-			if (!endpoint) return;
-			endpoint = endpoint.replace(/\/$/, '');
-			const url = `${endpoint}/models`;
+            let endpoint = provider === 'openai-compatible' ? customEndpoint : 'https://api.openai.com/v1';
+            if (!endpoint) return;
+            endpoint = endpoint.replace(/\/$/, '');
+            const url = `${endpoint}/models`;
 
-			const res = await fetch(url, {
-			  headers: { Authorization: `Bearer ${apiKey}` },
-		  	  signal,
-			});
+            const res = await fetch(url, {
+              headers: { Authorization: `Bearer ${apiKey}` },
+              signal,
+            });
 
-			if (!res.ok) {
-			  console.error(`Fetch error (${res.status}): ${res.statusText}`);
-			  return;
-			}
+            if (!res.ok) {
+              console.error(`Fetch error (${res.status}): ${res.statusText}`);
+              return;
+            }
 
-			const data = await res.json();
-			if (!signal.aborted) {
-			  let models = data.data?.map((m: any) => m.id) || []
-			  setAvailableModels(models);
-			  setModel(prev => models.includes(prev) ? prev : '');
-			}
-			break;
+            const data = await res.json();
+            if (!signal.aborted) {
+              let models = data.data?.map((m: any) => m.id) || []
+              setFetchedModels(models);
+              setModel(prev => models.includes(prev) ? prev : '');
+            }
+            break;
 
           case 'anthropic':
-			if (!apiKey) return;
-			{
-			  const res = await fetch('https://api.anthropic.com/v1/models', {
-			    headers: {
-				  'x-api-key': apiKey,
-				  'anthropic-version': '2023-06-01',
-				  'anthropic-dangerous-direct-browser-access': 'true',
-				},
-				signal,
-			  });
-			  if (!res.ok) {
-				console.error(`Fetch error (${res.status}): ${res.statusText}`);
-				return;
-			  }
-			  const data = await res.json();
-			  if (!signal.aborted) {
-				let models = data.data?.map((m: any) => m.id) || [];
-				setAvailableModels(models);
-			  	setModel(prev => models.includes(prev) ? prev : '');
-			  }
-			}
-			break;
+            if (!apiKey) return;
+            {
+              const res = await fetch('https://api.anthropic.com/v1/models', {
+                headers: {
+                  'x-api-key': apiKey,
+                  'anthropic-version': '2023-06-01',
+                  'anthropic-dangerous-direct-browser-access': 'true',
+                },
+                signal,
+              });
+              if (!res.ok) {
+                console.error(`Fetch error (${res.status}): ${res.statusText}`);
+                return;
+              }
+              const data = await res.json();
+              if (!signal.aborted) {
+                let models = data.data?.map((m: any) => m.id) || [];
+                setFetchedModels(models);
+                setModel(prev => models.includes(prev) ? prev : '');
+              }
+            }
+            break;
 
           case 'google':
             if (!apiKey) return;
@@ -196,16 +218,16 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
                 headers: { 'x-goog-api-key': apiKey },
                 signal,
               });
-			  if (!res.ok) {
-				console.error(`Fetch error (${res.status}): ${res.statusText}`);
-				return;
-			  }
+              if (!res.ok) {
+                console.error(`Fetch error (${res.status}): ${res.statusText}`);
+                return;
+              }
               const data = await res.json();
               if (!signal.aborted) {
-				let models = data.models?.map((m: any) => m.name) || [];
-				setAvailableModels(models);
-				setModel(prev => models.includes(prev) ? prev : '');
-			  }
+                let models = data.models?.map((m: any) => m.name) || [];
+                setFetchedModels(models);
+                setModel(prev => models.includes(prev) ? prev : '');
+              }
             }
             break;
 
@@ -216,34 +238,34 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
                 headers: { Authorization: `Bearer ${apiKey}` },
                 signal,
               });
-			  if (!res.ok) {
-				console.error(`Fetch error (${res.status}): ${res.statusText}`);
-				return;
-			  }
+              if (!res.ok) {
+                console.error(`Fetch error (${res.status}): ${res.statusText}`);
+                return;
+              }
               const data = await res.json();
               if (!signal.aborted) {
-				let models = data.models?.map((m: any) => m.id) || [];
-				setAvailableModels(models);
-				setModel(prev => models.includes(prev) ? prev : '');
-			  }
+                let models = data.models?.map((m: any) => m.id) || [];
+                setFetchedModels(models);
+                setModel(prev => models.includes(prev) ? prev : '');
+              }
             }
             break;
 
           case 'ollama':
-			{
-			  const res = await fetch('http://localhost:11434/api/tags', { signal });
-			  if (!res.ok) {
-				console.error(`Ollama fetch failed: ${res.statusText}`);
-				return;
-			  }
-			  const data = await res.json();
-			  if (!signal.aborted) {
-				let models = data.models?.map((m: any) => m.name || m.model) || [];
-				setAvailableModels(models);
-				setModel(prev => models.includes(prev) ? prev : '');
-			  }
-			}
-			break;
+            {
+              const res = await fetch('http://localhost:11434/api/tags', { signal });
+              if (!res.ok) {
+                console.error(`Ollama fetch failed: ${res.statusText}`);
+                return;
+              }
+              const data = await res.json();
+              if (!signal.aborted) {
+                let models = data.models?.map((m: any) => m.name || m.model) || [];
+                setFetchedModels(models);
+                setModel(prev => models.includes(prev) ? prev : '');
+              }
+            }
+            break;
 
           case 'openrouter':
             if (!apiKey) return;
@@ -252,26 +274,26 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
                 headers: { Authorization: `Bearer ${apiKey}` },
                 signal,
               });
-			  if (!res.ok) {
-				console.error(`Fetch error (${res.status}): ${res.statusText}`);
-				return;
-			  }
+              if (!res.ok) {
+                console.error(`Fetch error (${res.status}): ${res.statusText}`);
+                return;
+              }
               const data = await res.json();
               if (!signal.aborted) {
-				let models = data.data?.map((m: any) => m.id) || [];
-				setAvailableModels(models);
-				setModel(prev => models.includes(prev) ? prev : '');
-			  }
+                let models = data.data?.map((m: any) => m.id) || [];
+                setFetchedModels(models);
+                setModel(prev => models.includes(prev) ? prev : '');
+              }
             }
             break;
 
           default:
-            setAvailableModels([]);
+            setFetchedModels([]);
         }
       } catch (err: any) {
         if (err.name !== 'AbortError') {
           console.error('Failed to fetch models:', err);
-          setAvailableModels([]);
+          setFetchedModels([]);
         }
       }
     };
@@ -284,10 +306,15 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
   }, [provider, debouncedApiKey, customEndpoint]);
 
   useEffect(() => {
-    if (availableModels.length > 0 && model && !availableModels.includes(model)) {
-      setModel('');
+    if (combinedModels.length > 0 && model && model !== '') {
+      const isKnown = combinedModels.some(m => m.value === model);
+      if (!isKnown && !isCustomModel) {
+        setIsCustomModel(true);
+      } else if (isKnown && isCustomModel) {
+        setIsCustomModel(false);
+      }
     }
-  }, [model, availableModels]);
+  }, [model, combinedModels, isCustomModel]);
 
   const handleSave = async () => {
     localStorage.setItem('aiProvider', provider);
@@ -461,88 +488,122 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
             </div>
           )}
 
-		  <div className="relative">
-		    <label className={`block text-sm font-medium ${theme.label} mb-1`}>
-				API Key
-			</label>
-			<div className="flex items-center">
-			  <input
-				type={showApiKey ? "text" : "password"}
-				value={apiKey}
-				onChange={(e) => setApiKey(e.target.value)}
-				placeholder="Enter API key"
-				className={`flex-1 p-2 border rounded-lg focus:outline-none focus:ring-2 ${theme.input}`}
-			  />
-			  <button
-				type="button"
-				onClick={() => setShowApiKey(!showApiKey)}
-				className={`ml-2 p-2 rounded ${theme.closeButton}`}
-			  >
-				{showApiKey ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
-			  </button>
-			</div>
+          <div className="relative">
+            <label className={`block text-sm font-medium ${theme.label} mb-1`}>
+              API Key
+            </label>
+            <div className="flex items-center">
+              <input
+                type={showApiKey ? "text" : "password"}
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="Enter API key"
+                className={`flex-1 p-2 border rounded-lg focus:outline-none focus:ring-2 ${theme.input}`}
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className={`ml-2 p-2 rounded ${theme.closeButton}`}
+              >
+                {showApiKey ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
+              </button>
+            </div>
 
-			{/* Security status indicators */}
-			{keyProtectionLevel === 'webauthn' && (
-				<div className="mt-1 text-xs text-green-500 flex items-center gap-1">
-				  <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
-				    <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
-				  </svg>
-				  Protected with Passkey (WebAuthn)
-				</div>
-			)}
-			{keyProtectionLevel === 'memory-only' && (
-				<div className="mt-1 text-xs text-yellow-500 flex items-center gap-1">
-				  <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
-				    <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
-				  </svg>
-				  Stored in memory only (cleared on refresh)
-				</div>
-			)}
-			{!webauthnAvailable && apiKey && provider !== 'ollama' && !keyProtectionLevel && (
-			  <div className="mt-1 text-xs text-yellow-500">
-				⚠️ WebAuthn not available. Key will be stored in memory only.
-			  </div>
-			)}
-			{securityMessage && (
-			  <div className="mt-1 text-xs text-orange-400">
-				{securityMessage}
-			  </div>
-			)}
-		  </div>
+            {/* Security status indicators */}
+            {keyProtectionLevel === 'webauthn' && (
+              <div className="mt-1 text-xs text-green-500 flex items-center gap-1">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
+                </svg>
+                Protected with Passkey (WebAuthn)
+              </div>
+            )}
+            {keyProtectionLevel === 'memory-only' && (
+              <div className="mt-1 text-xs text-yellow-500 flex items-center gap-1">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                </svg>
+                Stored in memory only (cleared on refresh)
+              </div>
+            )}
+            {!webauthnAvailable && apiKey && provider !== 'ollama' && !keyProtectionLevel && (
+              <div className="mt-1 text-xs text-yellow-500">
+                ⚠️ WebAuthn not available. Key will be stored in memory only.
+              </div>
+            )}
+            {securityMessage && (
+              <div className="mt-1 text-xs text-orange-400">
+                {securityMessage}
+              </div>
+            )}
+          </div>
 
           <div>
             <label className={`block text-sm font-medium ${theme.label} mb-1`}>
               Model Name
             </label>
-            <select
-			  value={model}
-			  onChange={(e) => setModel(e.target.value)}
-			  className={`w-full p-2 border rounded-lg focus:outline-none focus:ring-2 ${theme.select}`}
-			>
-			<option value="">Select a model</option>
-			{availableModels.length > 0
-				? availableModels.map((m) => (
-					<option key={m} value={m}>{m}</option>
-				)) : <option disabled>No models available</option>
-			}
-			</select>
+
+            {provider === 'openai-compatible' || combinedModels.length === 0 ? (
+              <input
+                type="text"
+                value={model}
+                onChange={(e) => {
+                  setModel(e.target.value);
+                  setIsCustomModel(true);
+                }}
+                placeholder="Enter model name"
+                className={`w-full p-2 border rounded-lg focus:outline-none focus:ring-2 ${theme.input}`}
+              />
+            ) : (
+              <>
+                <select
+                  value={isCustomModel ? '__custom__' : model}
+                  onChange={(e) => {
+                    if (e.target.value === '__custom__') {
+                      setIsCustomModel(true);
+                      setModel('');
+                    } else {
+                      setIsCustomModel(false);
+                      setModel(e.target.value);
+                    }
+                  }}
+                  className={`w-full p-2 border rounded-lg focus:outline-none focus:ring-2 ${theme.select}`}
+                >
+                  <option value="">Select a model</option>
+                  {combinedModels.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                  <option value="__custom__">Custom...</option>
+                </select>
+                {isCustomModel && (
+                  <input
+                    type="text"
+                    value={model}
+                    onChange={(e) => setModel(e.target.value)}
+                    placeholder="Enter custom model name"
+                    className={`w-full p-2 mt-2 border rounded-lg focus:outline-none focus:ring-2 ${theme.input}`}
+                  />
+                )}
+              </>
+            )}
             {provider && (
               <div className={`mt-1 text-xs ${theme.helpText}`}>
-                {provider === 'openai' && 'Example: gpt-5, gpt-5-mini'}
-                {provider === 'anthropic' && 'Example: claude-opus-4-1-20250805, claude-sonnet-4-5-20250929'}
-                {provider === 'google' && 'Example: gemini-3-pro, gemini-2.5-flash'}
+                {provider === 'openai' && 'Example: gpt-4, gpt-4-mini'}
+                {provider === 'anthropic' && 'Example: claude-3-5-sonnet-241022'}
+                {provider === 'google' && 'Example: gemini-2.5-pro, gemini-2.5-flash'}
                 {provider === 'mistral' && 'Example: mistral-large-latest, mistral-medium-latest'}
-                {provider === 'openrouter' && 'Example: openai/gpt-5, meta-llama/llama-3.3-70b-instruct'}
+                {provider === 'openrouter' && 'Example: openai/gpt-4o, meta-llama/llama-3.3-70b-instruct'}
                 {provider === 'ollama' && (
                   <span className="text-orange-500 font-bold">
                     ⚠️ Must run: <code>OLLAMA_ORIGINS="*" ollama serve</code>
-                    <br/>Example models: tinyllama, qwen2.5:0.5b, llama3
+                    <br />Example models: tinyllama, qwen2.5:0.5b, llama3
                   </span>
                 )}
-                
               </div>
             )}
+
           </div>
 
           <div className={`border rounded-lg ${theme.advancedContainer}`}>
@@ -643,7 +704,7 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
 
           <button
             onClick={() => { handleSave().catch(console.warn); }}
-            disabled={isEncrypting || !provider || !model || (availableModels.length > 0 && !availableModels.includes(model)) || (provider !== 'ollama' && !apiKey) || (provider === 'openai-compatible' && !customEndpoint)}
+            disabled={isEncrypting || !provider || !model || (provider !== 'ollama' && !apiKey) || (provider === 'openai-compatible' && !customEndpoint)}
             className={`w-full py-2 rounded-lg transition-colors disabled:cursor-not-allowed ${isEncrypting || !provider || !model || (provider !== 'ollama' && !apiKey) || (provider === 'openai-compatible' && !customEndpoint)
               ? theme.saveButton.disabled
               : theme.saveButton.enabled

--- a/src/components/AIConfigPopup.tsx
+++ b/src/components/AIConfigPopup.tsx
@@ -418,6 +418,7 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
       // Clear the in-memory AI config in Zustand so stale keys don't persist
       const { setAIConfig } = useAppStore.getState();
       setAIConfig(null);
+      setIsCustomModel(false);
     }
   };
 
@@ -456,7 +457,11 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
             </label>
             <select
               value={provider}
-              onChange={(e) => setProvider(e.target.value)}
+              onChange={(e) => {
+                setProvider(e.target.value);
+                setModel('');
+                setIsCustomModel(false);
+              }}
               className={`w-full p-2 border rounded-lg focus:outline-none focus:ring-2 ${theme.select}`}
             >
               <option value="">Select a provider</option>

--- a/src/tests/ai-assistant/providerModels.test.ts
+++ b/src/tests/ai-assistant/providerModels.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { PROVIDER_MODELS, getModelsForProvider } from '../../ai-assistant/providerModels';
+
+describe('PROVIDER_MODELS', () => {
+    const expectedProviders = ['openai', 'anthropic', 'google', 'mistral', 'openrouter', 'ollama'];
+
+    it.each(expectedProviders)('should have models for provider "%s"', (provider) => {
+        expect(PROVIDER_MODELS[provider]).toBeDefined();
+        expect(PROVIDER_MODELS[provider].length).toBeGreaterThan(0);
+    });
+
+    it('should have non-empty label and value for every model entry', () => {
+        for (const provider of Object.keys(PROVIDER_MODELS)) {
+            for (const model of PROVIDER_MODELS[provider]) {
+                expect(model.label).toBeTruthy();
+                expect(model.value).toBeTruthy();
+            }
+        }
+    });
+
+    it('should not have duplicate values within the same provider', () => {
+        for (const provider of Object.keys(PROVIDER_MODELS)) {
+            const values = PROVIDER_MODELS[provider].map(m => m.value);
+            expect(new Set(values).size).toBe(values.length);
+        }
+    });
+});
+
+describe('getModelsForProvider', () => {
+    it('should return models for a known provider', () => {
+        const models = getModelsForProvider('openai');
+        expect(models.length).toBeGreaterThan(0);
+        expect(models[0]).toHaveProperty('label');
+        expect(models[0]).toHaveProperty('value');
+    });
+
+    it('should return an empty array for an unknown provider', () => {
+        expect(getModelsForProvider('unknown-provider')).toEqual([]);
+    });
+
+    it('should return an empty array for an empty string', () => {
+        expect(getModelsForProvider('')).toEqual([]);
+    });
+
+    it('should return correct models for each provider', () => {
+        expect(getModelsForProvider('openai').some(m => m.value === 'gpt-5.2')).toBe(true);
+        expect(getModelsForProvider('anthropic').some(m => m.value === 'claude-opus-4.6')).toBe(true);
+        expect(getModelsForProvider('google').some(m => m.value === 'gemini-2.5-pro')).toBe(true);
+        expect(getModelsForProvider('mistral').some(m => m.value === 'mistral-large-latest')).toBe(true);
+        expect(getModelsForProvider('openrouter').some(m => m.value === 'openai/gpt-5.2')).toBe(true);
+        expect(getModelsForProvider('ollama').some(m => m.value === 'llama3')).toBe(true);
+    });
+});

--- a/src/tests/components/AIConfigPopupModelSelect.test.tsx
+++ b/src/tests/components/AIConfigPopupModelSelect.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../../store/store', () => {
 
 describe('AIConfigPopup - Model Selection', () => {
     const mockOnClose = vi.fn();
-    const mockOnSave = vi.fn();
+
 
     beforeEach(() => {
         vi.clearAllMocks();
@@ -21,7 +21,7 @@ describe('AIConfigPopup - Model Selection', () => {
     });
 
     it('should show model dropdown when a provider is selected', () => {
-        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} />);
 
         // Select OpenAI provider
         const providerSelect = screen.getByDisplayValue('Select a provider');
@@ -32,7 +32,7 @@ describe('AIConfigPopup - Model Selection', () => {
     });
 
     it('should populate model dropdown with provider-specific models', () => {
-        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} />);
 
         const providerSelect = screen.getByDisplayValue('Select a provider');
         fireEvent.change(providerSelect, { target: { value: 'openai' } });
@@ -44,7 +44,7 @@ describe('AIConfigPopup - Model Selection', () => {
     });
 
     it('should show different models when switching providers', () => {
-        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} />);
 
         const providerSelect = screen.getByDisplayValue('Select a provider');
 
@@ -58,7 +58,7 @@ describe('AIConfigPopup - Model Selection', () => {
     });
 
     it('should reset model when provider changes', () => {
-        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} />);
 
         const providerSelect = screen.getByDisplayValue('Select a provider');
 
@@ -74,7 +74,7 @@ describe('AIConfigPopup - Model Selection', () => {
     });
 
     it('should show Custom option and text input when Custom is selected', () => {
-        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} />);
 
         const providerSelect = screen.getByDisplayValue('Select a provider');
         fireEvent.change(providerSelect, { target: { value: 'openai' } });
@@ -88,7 +88,7 @@ describe('AIConfigPopup - Model Selection', () => {
     });
 
     it('should show text input instead of dropdown for openai-compatible provider', () => {
-        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} />);
 
         const providerSelect = screen.getByDisplayValue('Select a provider');
         fireEvent.change(providerSelect, { target: { value: 'openai-compatible' } });
@@ -98,7 +98,7 @@ describe('AIConfigPopup - Model Selection', () => {
     });
 
     it('should include Custom option in the model dropdown', () => {
-        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} />);
 
         const providerSelect = screen.getByDisplayValue('Select a provider');
         fireEvent.change(providerSelect, { target: { value: 'google' } });

--- a/src/tests/components/AIConfigPopupModelSelect.test.tsx
+++ b/src/tests/components/AIConfigPopupModelSelect.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AIConfigPopup from '../../components/AIConfigPopup';
+
+// Mock the store
+vi.mock('../../store/store', () => {
+    return {
+        default: vi.fn((selector) => selector({
+            backgroundColor: '#ffffff',
+        })),
+    };
+});
+
+describe('AIConfigPopup - Model Selection', () => {
+    const mockOnClose = vi.fn();
+    const mockOnSave = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+    });
+
+    it('should show model dropdown when a provider is selected', () => {
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+
+        // Select OpenAI provider
+        const providerSelect = screen.getByDisplayValue('Select a provider');
+        fireEvent.change(providerSelect, { target: { value: 'openai' } });
+
+        // Model dropdown should appear with "Select a model" default
+        expect(screen.getByDisplayValue('Select a model')).toBeInTheDocument();
+    });
+
+    it('should populate model dropdown with provider-specific models', () => {
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+
+        const providerSelect = screen.getByDisplayValue('Select a provider');
+        fireEvent.change(providerSelect, { target: { value: 'openai' } });
+
+        // Check that OpenAI models appear
+        expect(screen.getByText('GPT-5.2')).toBeInTheDocument();
+        expect(screen.getByText('GPT-5 Mini')).toBeInTheDocument();
+        expect(screen.getByText('o3')).toBeInTheDocument();
+    });
+
+    it('should show different models when switching providers', () => {
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+
+        const providerSelect = screen.getByDisplayValue('Select a provider');
+
+        // Select Anthropic
+        fireEvent.change(providerSelect, { target: { value: 'anthropic' } });
+        expect(screen.getByText('Claude Opus 4.6')).toBeInTheDocument();
+
+        // Switch to Google
+        fireEvent.change(providerSelect, { target: { value: 'google' } });
+        expect(screen.getByText('Gemini 2.5 Pro')).toBeInTheDocument();
+    });
+
+    it('should reset model when provider changes', () => {
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+
+        const providerSelect = screen.getByDisplayValue('Select a provider');
+
+        // Select OpenAI and pick a model
+        fireEvent.change(providerSelect, { target: { value: 'openai' } });
+        const modelSelect = screen.getByDisplayValue('Select a model');
+        fireEvent.change(modelSelect, { target: { value: 'gpt-5.2' } });
+        expect(screen.getByDisplayValue('GPT-5.2')).toBeInTheDocument();
+
+        // Switch provider — model should reset
+        fireEvent.change(providerSelect, { target: { value: 'anthropic' } });
+        expect(screen.getByDisplayValue('Select a model')).toBeInTheDocument();
+    });
+
+    it('should show Custom option and text input when Custom is selected', () => {
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+
+        const providerSelect = screen.getByDisplayValue('Select a provider');
+        fireEvent.change(providerSelect, { target: { value: 'openai' } });
+
+        // Select "Custom..."
+        const modelSelect = screen.getByDisplayValue('Select a model');
+        fireEvent.change(modelSelect, { target: { value: '__custom__' } });
+
+        // Custom text input should appear
+        expect(screen.getByPlaceholderText('Enter custom model name')).toBeInTheDocument();
+    });
+
+    it('should show text input instead of dropdown for openai-compatible provider', () => {
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+
+        const providerSelect = screen.getByDisplayValue('Select a provider');
+        fireEvent.change(providerSelect, { target: { value: 'openai-compatible' } });
+
+        // Should show plain text input, not a dropdown
+        expect(screen.getByPlaceholderText('Enter model name')).toBeInTheDocument();
+    });
+
+    it('should include Custom option in the model dropdown', () => {
+        render(<AIConfigPopup isOpen={true} onClose={mockOnClose} onSave={mockOnSave} />);
+
+        const providerSelect = screen.getByDisplayValue('Select a provider');
+        fireEvent.change(providerSelect, { target: { value: 'google' } });
+
+        expect(screen.getByText('Custom...')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
# Closes #780 

This PR improves the AI configuration UX by replacing the free-text model input with a provider-aware dropdown. It suggests popular models for each provider and includes a **Custom** option for manual entry when needed. This helps reduce errors caused by typos or incorrect model names.

### Changes
- Added a `PROVIDER_MODELS` constant with curated model lists for supported providers.
- Replaced the model text input with a provider-based dropdown in `AIConfigPopup`.
- Added a **Custom** option that shows a manual input field when selected.
- Reset the model selection when the provider changes.
- Restored custom models from `localStorage` if the saved model is not in the provider list.
- Added unit tests for `providerModels` and the model selection behavior in `AIConfigPopup`.

### Flags
- For **OpenAI-compatible APIs**, the model field remains a text input because models can be user-defined.
- Existing Ollama help text and warnings remain unchanged.

### Screenshots or Video
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/940fbddd-5711-4885-b2da-63d5dc055f01" />

#### Test Results
<img width="1356" height="605" alt="Screenshot 2026-03-07 155143" src="https://github.com/user-attachments/assets/71645a86-f0fc-42a9-9f99-4e17b29fa358" />


### Related Issues
- Issue #780 

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commit messages follow AP format
- [x] Extend the documentation, if necessary