### PR TITLE
fix: disable infinite animation loop on Learn button (#614)

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -198,7 +198,7 @@ function Navbar() {
   const location = useLocation();
 
   const props = useSpring({
-    loop: true,
+    loop: false,
     from: { opacity: 0.5, boxShadow: "0px 0px 0px rgba(255, 255, 255, 0)" },
     to: [
       { opacity: 1, boxShadow: "0px 0px 5px rgba(255, 255, 255, 1)" },


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #614 
<!--- Provide an overall summary of the pull request --> fix: disable infinite animation loop on Learn button (#614)

### Description
This PR resolves the issue where the "Learn" button in the Navbar would pulse indefinitely. By changing the loop property to false, the animation now correctly plays once upon mounting and then remains static, preventing a persistent visual distraction for users.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Changed loop: true to loop: false in the useSpring hook for the "Learn" button.
- <TWO> Verified that the animation now runs once on page load and then stops, resolving the infinite pulsing distraction reported in #614.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
https://github.com/user-attachments/assets/948849b8-fb34-4660-80cb-61c1b9a3e15a

### Related Issues
- Issue #614 
- Pull Request #


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`