### PR TITLE
fix(editors-theme): use explicit dark-mode check for All Editors

### DIFF
--- a/src/editors/ConcertoEditor.tsx
+++ b/src/editors/ConcertoEditor.tsx
@@ -2,6 +2,7 @@ import { useMonaco } from "@monaco-editor/react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, MutableRefObject } from "react";
 import * as monaco from "monaco-editor";
 import useAppStore from "../store/store";
+import useThemeName from "../hooks/useThemeName";
 import { useCodeSelection } from "../components/CodeSelectionMenu";
 import { registerAutocompletion } from "../ai-assistant/autocompletion";
 import { registerEditor, unregisterEditor } from "../utils/editorNavigation";
@@ -124,18 +125,14 @@ export default function ConcertoEditor({
 }: ConcertoEditorProps) {
   const { handleSelection, MenuComponent } = useCodeSelection("concerto");
   const monacoInstance = useMonaco();
-  const { error, backgroundColor, aiConfig, showLineNumbers } = useAppStore((state) => ({
+  const { error, aiConfig, showLineNumbers } = useAppStore((state) => ({
     error: state.error,
-    backgroundColor: state.backgroundColor,
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
   }));
   const ctoErr = error?.startsWith("c:") ? error : undefined;
 
-  const themeName = useMemo(
-    () => (backgroundColor ? "darkTheme" : "lightTheme"),
-    [backgroundColor]
-  );
+  const themeName = useThemeName();
 
   const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
     minimap: { enabled: false },

--- a/src/editors/JSONEditor.tsx
+++ b/src/editors/JSONEditor.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useMemo, useCallback, useEffect } from "react";
 import * as monaco from "monaco-editor";
 import useAppStore from "../store/store";
+import useThemeName from "../hooks/useThemeName";
 import { useCodeSelection } from "../components/CodeSelectionMenu";
 import { registerAutocompletion } from "../ai-assistant/autocompletion";
 import { registerEditor, unregisterEditor } from "../utils/editorNavigation";
@@ -20,16 +21,12 @@ export default function JSONEditor({
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("json");
 
-  const { backgroundColor, aiConfig, showLineNumbers } = useAppStore((state) => ({
-    backgroundColor: state.backgroundColor,
+  const { aiConfig, showLineNumbers } = useAppStore((state) => ({
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
   }));
 
-  const themeName = useMemo(
-    () => (backgroundColor ? "darkTheme" : "lightTheme"),
-    [backgroundColor]
-  );
+  const themeName = useThemeName();
 
   const options: monaco.editor.IStandaloneEditorConstructionOptions = useMemo(() => ({
     minimap: { enabled: false },

--- a/src/editors/MarkdownEditor.tsx
+++ b/src/editors/MarkdownEditor.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useMemo, useCallback, useEffect, MutableRefObject } from "react";
 import useAppStore from "../store/store";
+import useThemeName from "../hooks/useThemeName";
 import { useMonaco } from "@monaco-editor/react";
 import { useCodeSelection } from "../components/CodeSelectionMenu";
 import type { editor } from "monaco-editor";
@@ -31,10 +32,7 @@ export default function MarkdownEditor({
   }));
   const monaco = useMonaco();
 
-  const themeName = useMemo(
-    () => (backgroundColor ? "darkTheme" : "lightTheme"),
-    [backgroundColor]
-  );
+  const themeName = useThemeName();
 
   useEffect(() => {
     if (monaco) {

--- a/src/hooks/useThemeName.ts
+++ b/src/hooks/useThemeName.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import useAppStore from "../store/store";
+
+/**
+ * Custom hook that derives the editor theme name from the current background color.
+ * Returns "darkTheme" when the background is dark (#121212), otherwise "lightTheme".
+ */
+export default function useThemeName(): string {
+  const backgroundColor = useAppStore((state) => state.backgroundColor);
+
+  const themeName = useMemo(
+    () => (backgroundColor === "#121212" ? "darkTheme" : "lightTheme"),
+    [backgroundColor]
+  );
+
+  return themeName;
+}


### PR DESCRIPTION
# fix(editors): use explicit dark-mode check for Monaco theme selection

Closes #819 

### Changes
- Replaced truthy string theme checks with explicit comparison in all editor components.
- Updated theme selection to use `backgroundColor === "#121212"` for `darkTheme` and `lightTheme` otherwise.
- Applied fix in:
  - `src/editors/*.tsx`

### Flags
- Scope is limited to editor theme selection logic only.
- No behavior change expected outside Editor theme resolution.

### Screenshots or Video
<img width="1919" height="1079" alt="Screenshot 2026-03-14 165443" src="https://github.com/user-attachments/assets/8a312b32-f1c7-4193-89eb-b78a1e9c0f55" />
<img width="1919" height="1035" alt="Screenshot 2026-03-14 165750" src="https://github.com/user-attachments/assets/ec4226bb-1c63-46e3-a4bf-b07892e5f9fd" />


### Related Issues
- Issue #819 
- Pull Request #820

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`