### PR TITLE
docs: add AGENTS.md with Ant Design guidelines for agent development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent Development Guidelines
+
+## UI Component Library
+
+This project uses **Ant Design (antd)** as its primary UI component 
+and styling library.
+
+### Rules for Agents
+
+- **DO** use Ant Design components for all UI elements
+  (Button, Typography, Form, Input, Select, Modal, etc.)
+- **DO** use Ant Design's theme token system for colors and spacing:
+```tsx
+  import { theme } from 'antd';
+  const { token } = theme.useToken();
+  // Use token.colorText, token.colorBgContainer, etc.
+```
+- **DO NOT** use Tailwind CSS utility classes for new development
+- **DO NOT** use inline styles with hardcoded color values
+- **DO NOT** add new Tailwind classes to existing components
+
+### Dark/Light Mode
+
+Dark and light mode is controlled through Ant Design's 
+`ConfigProvider` and theme tokens. Do not use manual 
+`isDarkMode` checks with Tailwind classes. Use 
+`token.colorText`, `token.colorBgContainer` etc. instead.
+
+### Example — Correct Pattern
+```tsx
+import { Typography, theme } from 'antd';
+const { token } = theme.useToken();
+const { Text } = Typography;
+
+// Correct
+<Text>{label}</Text>
+
+// Wrong
+<span className={isDarkMode ? 'text-gray-200' : 'text-gray-700'}>
+  {label}
+</span>
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,40 +2,42 @@
 
 ## UI Component Library
 
-This project uses **Ant Design (antd)** as its primary UI component 
-and styling library.
+This project uses **Ant Design (antd)** as its primary UI component and styling library.
 
-### Rules for Agents
+## Rules for Agents
 
-- **DO** use Ant Design components for all UI elements
-  (Button, Typography, Form, Input, Select, Modal, etc.)
-- **DO** use Ant Design's theme token system for colors and spacing:
+### ✅ DO
+- Use Ant Design components for all UI elements (`Button`, `Typography`, `Form`, `Input`, `Select`, `Modal`, etc.)
+- Use Ant Design's theme token system for colors and spacing
+- Use `theme.useToken()` for dark/light mode aware colors
+
+### ❌ DO NOT
+- Use Tailwind CSS utility classes for new development
+- Use inline styles with hardcoded color values
+- Add new Tailwind classes to existing components
+
+## Dark/Light Mode
+
+Dark and light mode is controlled through Ant Design's `ConfigProvider` and theme tokens. Do **not** use manual `isDarkMode` checks with Tailwind classes.
 ```tsx
-  import { theme } from 'antd';
-  const { token } = theme.useToken();
-  // Use token.colorText, token.colorBgContainer, etc.
-```
-- **DO NOT** use Tailwind CSS utility classes for new development
-- **DO NOT** use inline styles with hardcoded color values
-- **DO NOT** add new Tailwind classes to existing components
-
-### Dark/Light Mode
-
-Dark and light mode is controlled through Ant Design's 
-`ConfigProvider` and theme tokens. Do not use manual 
-`isDarkMode` checks with Tailwind classes. Use 
-`token.colorText`, `token.colorBgContainer` etc. instead.
-
-### Example — Correct Pattern
-```tsx
-import { Typography, theme } from 'antd';
+// ✅ Correct
+import { theme } from 'antd';
 const { token } = theme.useToken();
+// Use token.colorText, token.colorBgContainer, etc.
+
+// ❌ Wrong
+const label = isDarkMode ? 'text-gray-200' : 'text-gray-700';
+```
+
+## Component Example
+```tsx
+// ✅ Correct
+import { Typography } from 'antd';
 const { Text } = Typography;
 
-// Correct
 <Text>{label}</Text>
 
-// Wrong
+// ❌ Wrong
 <span className={isDarkMode ? 'text-gray-200' : 'text-gray-700'}>
   {label}
 </span>


### PR DESCRIPTION
## Summary
Adds an `AGENTS.md` file with clear guidelines for agents to use 
Ant Design (antd) instead of Tailwind CSS for all new UI development.

This was explicitly requested by @sanketshevkar during review of #805:
> "Can you please write up a AGENTS.md with a guideline for agents 
> to not use tailwind styles, instead use ant-ui design library"

## Changes
- Added `AGENTS.md` at project root with:
  - Clear rules on using Ant Design components
  - Guidelines for dark/light mode using `theme.useToken()` 
    instead of Tailwind dark mode classes
  - Code examples showing correct vs incorrect patterns

## Testing
- No functional changes — documentation only
- All 75 unit tests pass

### Screenshots or Video
Documentation only — no UI changes.

### Related Issues
- PR #805

### Author Checklist
- [x] Ensure you provide a DCO sign-off
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [x] Extend the documentation, if necessary
- [x] Merging to main from fork:branchname