### PR TITLE
chore(theme): replace hardcoded brand colors with centralized theme constants

### DIFF
--- a/src/AgreementHtml.tsx
+++ b/src/AgreementHtml.tsx
@@ -1,4 +1,4 @@
-
+import { colors } from './utils/theme';
 import { LoadingOutlined } from "@ant-design/icons";
 import { Spin } from "antd";
 import useAppStore from "./store/store";
@@ -41,7 +41,7 @@ function AgreementHtml({ loading, isModal }: { loading: boolean; isModal?: boole
       </p>
       {loading ? (
         <div style={{ flex: 1, display: "flex", justifyContent: "center", alignItems: "center" }}>
-          <Spin indicator={<LoadingOutlined style={{ fontSize: 42, color: "#19c6c7" }} spin />} />
+          <Spin indicator={<LoadingOutlined style={{ fontSize: 42, color: colors.primary }} spin />} />
         </div>
       ) : (
         <div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import MainContainer from "./pages/MainContainer";
 import PlaygroundSidebar from "./components/PlaygroundSidebar";
 import "./styles/App.css";
 import AIConfigPopup from "./components/AIConfigPopup";
+import { colors } from './utils/theme';
 
 const { Content } = Layout;
 
@@ -152,7 +153,7 @@ const App = () => {
 const Spinner = () => (
   <div className="app-spinner-container">
     <Spin
-      indicator={<LoadingOutlined style={{ fontSize: 42, color: "#19c6c7" }} spin />}
+      indicator={<LoadingOutlined style={{ fontSize: 42, color: colors.primary }} spin />}
     />
   </div>
 );

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -1,3 +1,4 @@
+import { colors } from '../utils/theme';
 import React, { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
@@ -83,7 +84,7 @@ const LearnContent: React.FC<LearnContentProps> = ({ file }) => {
       >
         <Spin
           indicator={
-            <LoadingOutlined style={{ fontSize: 42, color: "#19c6c7" }} spin />
+            <LoadingOutlined style={{ fontSize: 42, color: colors.primary }} spin />
           }
         />
       </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { colors } from '../utils/theme';
 import { Component, ErrorInfo, ReactNode } from 'react';
 import useAppStore from '../store/store';
 
@@ -57,7 +58,7 @@ class ErrorBoundary extends Component<Props, State> {
             style={{
               padding: '0.75rem 1.5rem',
               fontSize: '1rem',
-              backgroundColor: '#19c6c7',
+              backgroundColor: colors.primary,
               color: 'white',
               border: 'none',
               borderRadius: '4px',

--- a/src/components/FabButton.tsx
+++ b/src/components/FabButton.tsx
@@ -1,3 +1,4 @@
+import { colors } from '../utils/theme';
 import { Fab, Action } from "react-tiny-fab";
 import { MdExplore } from "react-icons/md";
 import { FaCircleQuestion } from "react-icons/fa6";
@@ -16,7 +17,7 @@ const FloatingFAB = () => {
         icon={<FaCircleQuestion />}
         alwaysShowTitle
         mainButtonStyles={{
-          backgroundColor: "#1B2540",
+          backgroundColor: colors.navy,
           color: "white",
           width: "50px",
           height: "50px",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import { colors } from '../utils/theme';
 import React, { useState } from "react";
 import { Layout, Row, Col, Typography, Space, Button, Image, Grid } from "antd";
 import {
@@ -24,7 +25,7 @@ const CustomFooter: React.FC = () => {
     <Footer
       id="footer"
       style={{
-        background: "#1b2540",
+        background: colors.navy,
         color: "white",
         padding: "50px 50px 20px 50px",
       }}
@@ -53,9 +54,9 @@ const CustomFooter: React.FC = () => {
                 size="large"
                 style={{
                   padding: "5px 30px",
-                  backgroundColor: "#19c6c7",
+                  backgroundColor: colors.primary,
                   borderRadius: "5px",
-                  color: "#050c40",
+                  color: colors.darkNavy,
                   textAlign: "center",
                   border: "none",
                 }}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,3 +1,4 @@
+import { colors } from '../utils/theme';
 import { useState } from "react";
 import { useSpring, animated } from "react-spring";
 import { useLocation, Link } from "react-router-dom";
@@ -268,9 +269,9 @@ function Navbar() {
   const isLearnPage = location.pathname.startsWith("/learn");
 
   return (
-    <div className={`fixed top-0 left-0 right-0 z-50 bg-[#1b2540] h-16 flex items-center ${
+    <div className={`fixed top-0 left-0 right-0 z-50 h-16 flex items-center ${
       screens.lg ? "px-10" : screens.md ? "px-2.5" : "px-2.5"
-    }`}>
+    }`} style={{ backgroundColor: colors.navy }}>
       <div
         className={`cursor-pointer ${menuItemClasses("home", false)}`}
         onMouseEnter={() => setHovered("home")}
@@ -332,7 +333,8 @@ function Navbar() {
             <Link to="/learn/intro" className="learnNow-button">
               <animated.button
                 style={props}
-                className="px-[22px] py-[10px] bg-[#19c6c7] text-[#050c40] border-none rounded-md cursor-pointer"
+                className="px-[22px] py-[10px] border-none rounded-md cursor-pointer"
+style={{ backgroundColor: colors.primary, color: colors.darkNavy }}
               >
                 Learn
               </animated.button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -332,10 +332,9 @@ function Navbar() {
           >
             <Link to="/learn/intro" className="learnNow-button">
               <animated.button
-                style={props}
-                className="px-[22px] py-[10px] border-none rounded-md cursor-pointer"
-style={{ backgroundColor: colors.primary, color: colors.darkNavy }}
-              >
+  style={{ ...props, backgroundColor: colors.primary, color: colors.darkNavy }}
+  className="px-[22px] py-[10px] border-none rounded-md cursor-pointer"
+>
                 Learn
               </animated.button>
             </Link>

--- a/src/components/Tour.ts
+++ b/src/components/Tour.ts
@@ -1,3 +1,4 @@
+import { colors } from '../utils/theme';
 import Shepherd from "shepherd.js";
 import "shepherd.js/dist/css/shepherd.css";
 
@@ -7,7 +8,7 @@ style.textContent = `
     background-color: #6c757d !important;
   }
   .shepherd-button {
-    background-color: #050c40 !important; 
+    background-color: ${colors.darkNavy} !important;
     color: white !important;
   }
 `;

--- a/src/styles/components/Content.ts
+++ b/src/styles/components/Content.ts
@@ -1,3 +1,4 @@
+import { colors } from '../../utils/theme';
 import styled from "styled-components";
 
 export const ContentContainer = styled.div`
@@ -23,7 +24,7 @@ export const ContentContainer = styled.div`
   }
 
   a {
-    color: #19c6c7;
+    color: ${colors.primary};
     text-decoration: none;
     &:hover {
       text-decoration: underline;
@@ -113,10 +114,10 @@ export const NavigationButtons = styled.div`
 
 export const NavigationButton = styled.button`
   padding: 0.625rem 1.25rem;
-  border: 0.125rem solid #19c6c7;
+  border: 0.125rem solid ${colors.primary};
   border-radius: 0.25rem;
   background-color: white;
-  color: #1b2540;
+  color: ${colors.navy}
   cursor: pointer;
   font-weight: 600;
   font-size: 1rem;
@@ -132,7 +133,7 @@ export const NavigationButton = styled.button`
   }
 
   &:hover:not(:disabled) {
-    background-color: #19c6c7;
+    background-color: ${colors.primary};
     color: white;
     text-decoration: underline;
   }

--- a/src/styles/components/Content.ts
+++ b/src/styles/components/Content.ts
@@ -117,7 +117,7 @@ export const NavigationButton = styled.button`
   border: 0.125rem solid ${colors.primary};
   border-radius: 0.25rem;
   background-color: white;
-  color: ${colors.navy}
+  color: ${colors.navy};
   cursor: pointer;
   font-weight: 600;
   font-size: 1rem;

--- a/src/styles/components/Sidebar.ts
+++ b/src/styles/components/Sidebar.ts
@@ -1,3 +1,4 @@
+import { colors } from '../../utils/theme';
 import styled from "styled-components";
 import { NavLink } from "react-router-dom";
 
@@ -48,7 +49,7 @@ export const SidebarLink = styled(NavLink)`
     background-color: var(--active-bg-color) !important;
     color: var(--active-text-color) !important;
     font-weight: 600;
-    border-left: 2.5px solid #19c6c7;
+    border-left: 2.5px solid ${colors.primary};
   }
 
   &:hover {
@@ -73,7 +74,7 @@ export const HelperBox = styled.div`
 export const HelperIcon = styled.div`
   margin-right: 0.5rem;
   font-size: 1.2rem;
-  color: #19c6c7;
+  color: ${colors.primary};
 `;
 
 export const HelperText = styled.div`
@@ -81,7 +82,7 @@ export const HelperText = styled.div`
   color: #333;
 
   a {
-    color: #19c6c7 !important;
+    color: ${colors.primary} !important;
     text-decoration: none;
 
     &:hover {

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,19 @@
+/**
+ * Accord Project Brand Color Tokens
+ * 
+ * Single source of truth for brand colors.
+ * Use these constants instead of hardcoded hex values.
+ * 
+ * For Ant Design components, prefer using theme tokens
+ * from theme.useToken() where possible.
+ */
+export const colors = {
+  /** Primary teal — used for buttons, highlights, borders */
+  primary: '#19c6c7',
+  
+  /** Navy — used for navbar, footer backgrounds */
+  navy: '#1b2540',
+  
+  /** Dark navy — used for text on primary backgrounds */
+  darkNavy: '#050c40',
+} as const;


### PR DESCRIPTION
## Summary
Replaces hardcoded Accord Project brand color values scattered 
across 11 files with a centralized `src/utils/theme.ts` constants file.

## Problem
Three brand colors were hardcoded directly in 11+ files:
- `#19c6c7` (primary teal)
- `#1b2540` (navy)
- `#050c40` (dark navy)

This meant any brand color change would require manually 
updating every file — a maintenance nightmare.

## Solution
Created `src/utils/theme.ts` as a single source of truth:
```ts
export const colors = {
  primary: '#19c6c7',
  navy: '#1b2540', 
  darkNavy: '#050c40',
} as const;
```

## Files Changed
- `src/utils/theme.ts` — new centralized color constants
- `src/AgreementHtml.tsx`
- `src/App.tsx`
- `src/components/Content.tsx`
- `src/components/ErrorBoundary.tsx`
- `src/components/FabButton.tsx`
- `src/components/Footer.tsx`
- `src/components/Navbar.tsx`
- `src/components/Tour.ts`
- `src/styles/components/Content.ts`
- `src/styles/components/Sidebar.ts`

## Testing
- No visual changes — colors are identical
- All 75 unit tests pass

### Screenshots or Video
No visual changes — refactor only.

### Related Issues
- Addresses feedback from #805 to centralize styling
- Complements AGENTS.md guidelines from #821

### Author Checklist
- [x] Ensure you provide a DCO sign-off
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to main from fork:branchname