### PR TITLE
chore: remove console.log from tour initialization in store.ts

### DIFF
--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -402,9 +402,7 @@ const useAppStore = create<AppState>()(
             error: null,
           });
         },
-        startTour: () => {
-          console.log('Starting tour...');
-        },
+        startTour: () => {},
       }
     })
   )


### PR DESCRIPTION
## Summary
Removes a leftover `console.log` debug statement from 
the tour initialization function in `store.ts`.

## Problem
A `console.log('Starting tour...')` statement was left 
in production code inside the `startTour` function. 
Debug logs should never appear in production as they:
- Expose internal implementation details
- Add unnecessary noise to browser console
- Are considered bad practice in production code

## Changes
- Removed `console.log('Starting tour...')` from 
  `startTour` function in `src/store/store.ts`

## Testing
- All 75 unit tests pass
- No functional changes

### Screenshots or Video
No UI changes.

### Related Issues
None

### Author Checklist
- [x] Ensure you provide a DCO sign-off
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to main from fork:branchname