### PR TITLE
Test Template Playground with Concerto v4 beta.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -446,21 +446,10 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
-      "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
     "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.8.tgz",
-      "integrity": "sha512-W4424FbOTfiTKzpNZR2yweqWAMli8yYRSi7hJfvLlSPDQwSoY5sNmVeTEvjpHUcbZkaVN/Ok5y3lXjFVupJlHw==",
-      "hasInstallScript": true,
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
+      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "template_playground",
       "version": "0.0.0",
       "dependencies": {
-        "@accordproject/concerto-core": "^3.25.7",
+        "@accordproject/concerto-core": "^4.0.0-beta.1",
         "@accordproject/markdown-common": "^0.17.2",
         "@accordproject/markdown-template": "^0.17.2",
         "@accordproject/markdown-transform": "^0.17.2",
@@ -133,6 +133,59 @@
         "npm": ">=10"
       }
     },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core": {
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@accordproject/cicero-core/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -144,6 +197,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/@accordproject/cicero-core/node_modules/semver": {
       "version": "7.5.3",
@@ -158,6 +217,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@accordproject/cicero-core/node_modules/yallist": {
@@ -313,13 +385,38 @@
       }
     },
     "node_modules/@accordproject/concerto-core": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
-      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.0.0-beta.1.tgz",
+      "integrity": "sha512-vRdI+MeuzmsS1hpTnJx3CMoQ+RDq3EYmLUMHHii+UvQeNd6YJQn1CQKflf3jO5CD1AbFLun/ymd4Y6oyqEEd1w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7",
+        "@accordproject/concerto-codegen": "^3.16.2",
+        "@accordproject/concerto-cto": "4.0.0-beta.1",
+        "@accordproject/concerto-metamodel": "^4.0.0-alpha.0",
+        "@accordproject/concerto-util": "4.0.0-beta.1",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.24.0.tgz",
+      "integrity": "sha512-JrrBw3JMwtogiYPjBaRV6CZCKi2hXIdOVzyFslshfBMe3dkm94iloW8ASr3tsnWMfjuDUinsTksX/wfHJ9DXgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.24.0",
+        "@accordproject/concerto-metamodel": "^3.12.4",
+        "@accordproject/concerto-util": "3.24.0",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
@@ -328,12 +425,148 @@
         "semver": "7.6.3",
         "urijs": "1.19.11",
         "uuid": "11.0.3",
-        "yaml": "2.8.0"
+        "yaml": "^2.8.0"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
       }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.24.0.tgz",
+      "integrity": "sha512-DCTdUE3qExe3CCkg3PO1yBhj0/CGqY5al+kLkQuZ3p/MfFRZWkWMNdox6g7S9VtednRb5NPhkrLwlNRpJbkcmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "3.12.4",
+        "@accordproject/concerto-util": "3.24.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.4.tgz",
+      "integrity": "sha512-7EmrdRc+ocX1Km5TMfNWfNzAvE901BV6NYmCEPf+H8MjHgnJWz6LFbQ3D5ppF3ar8325FM40mMKiDUuSTFXvTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.8.tgz",
+      "integrity": "sha512-W4424FbOTfiTKzpNZR2yweqWAMli8yYRSi7hJfvLlSPDQwSoY5sNmVeTEvjpHUcbZkaVN/Ok5y3lXjFVupJlHw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.24.0.tgz",
+      "integrity": "sha512-zY33oFYTpgKqEfunx5WhcaqbXzYmJrywD4+XicyMiS3hCgi1+92hUd303lC9qywvCUybkiGXrizrldOtcqnXWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "debug": "4.3.7",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.0.0-beta.1.tgz",
+      "integrity": "sha512-qU7XeEgcmuvdqm0C49BRZSUmslmRolyDOmQ2CD8IL7uYGuqXhSihX9pk247STfv1/3UY1aw50XIJcCLjLUGqaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-codegen": "^3.16.2",
+        "@accordproject/concerto-metamodel": "^4.0.0-alpha.0",
+        "@accordproject/concerto-util": "4.0.0-beta.1",
+        "acorn": "^8.15.0",
+        "schema-utils": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-JYSBk4NA6P41MjJCVe4WrA1QW1iTJ2Bfkd1f8EcfnhfuCtH+rmQItoTV8X1pb/+ql+3gVMfitaE1klKiUMMJGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "3.24.0",
+        "@accordproject/concerto-util": "3.24.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-metamodel/node_modules/@accordproject/concerto-util": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.24.0.tgz",
+      "integrity": "sha512-zY33oFYTpgKqEfunx5WhcaqbXzYmJrywD4+XicyMiS3hCgi1+92hUd303lC9qywvCUybkiGXrizrldOtcqnXWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "debug": "4.3.7",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util": {
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.0.0-beta.1.tgz",
+      "integrity": "sha512-PzVgEAnU9Zu2fdrMqeFoF5E9AvfcGalJezHjqZyHAzGKnxgh6BYfZKZiHroIW0BGeCPNSm1vnszYYYVVkUYvUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-codegen": "^3.16.2",
+        "@supercharge/promise-pool": "1.7.0",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-util/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-core/node_modules/debug": {
       "version": "4.3.7",
@@ -366,6 +599,21 @@
       ],
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@accordproject/concerto-cto": {
@@ -468,10 +716,51 @@
         "npm": ">=9"
       }
     },
+    "node_modules/@accordproject/markdown-cicero/node_modules/@accordproject/concerto-core": {
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
     "node_modules/@accordproject/markdown-cicero/node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
+    },
+    "node_modules/@accordproject/markdown-cicero/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@accordproject/markdown-cicero/node_modules/entities": {
       "version": "4.5.0",
@@ -524,6 +813,12 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
+    "node_modules/@accordproject/markdown-cicero/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/@accordproject/markdown-cicero/node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -549,6 +844,19 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+    },
+    "node_modules/@accordproject/markdown-cicero/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/@accordproject/markdown-cicero/node_modules/winston": {
       "version": "3.17.0",
@@ -585,12 +893,53 @@
         "npm": ">=9"
       }
     },
+    "node_modules/@accordproject/markdown-common/node_modules/@accordproject/concerto-core": {
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
     "node_modules/@accordproject/markdown-common/node_modules/@xmldom/xmldom": {
       "version": "0.9.8",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
       "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
       "engines": {
         "node": ">=14.6"
+      }
+    },
+    "node_modules/@accordproject/markdown-common/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@accordproject/markdown-common/node_modules/entities": {
@@ -633,10 +982,29 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
+    "node_modules/@accordproject/markdown-common/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/@accordproject/markdown-common/node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+    },
+    "node_modules/@accordproject/markdown-common/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/@accordproject/markdown-html": {
       "version": "0.17.2",
@@ -840,6 +1208,47 @@
         "npm": ">=9"
       }
     },
+    "node_modules/@accordproject/markdown-template/node_modules/@accordproject/concerto-core": {
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/markdown-template/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@accordproject/markdown-template/node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -880,10 +1289,29 @@
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
+    "node_modules/@accordproject/markdown-template/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/@accordproject/markdown-template/node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+    },
+    "node_modules/@accordproject/markdown-template/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/@accordproject/markdown-transform": {
       "version": "0.17.2",
@@ -901,6 +1329,66 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/markdown-transform/node_modules/@accordproject/concerto-core": {
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/markdown-transform/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/markdown-transform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/markdown-transform/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@accordproject/template-engine": {
@@ -930,6 +1418,66 @@
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.38.0"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-core": {
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
+      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "3.25.7",
+        "@accordproject/concerto-metamodel": "3.12.6",
+        "@accordproject/concerto-util": "3.25.7",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "2.8.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@accordproject/template-engine/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7562,7 +8110,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lz-string": {
@@ -8391,7 +8938,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -8408,7 +8954,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -9689,6 +10234,15 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -19544,7 +20098,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@accordproject/concerto-core": "^3.25.7",
+    "@accordproject/concerto-core": "^4.0.0-beta.1",
     "@accordproject/markdown-common": "^0.17.2",
     "@accordproject/markdown-template": "^0.17.2",
     "@accordproject/markdown-transform": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
     "vite-plugin-node-stdlib-browser": "^0.2.1",
     "vitest": "^1.6.0"
   },
+  "overrides": {
+    "@accordproject/concerto-core@3.24.0": {
+      "@accordproject/concerto-metamodel": "3.12.6"
+    }
+  },
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -84,10 +84,11 @@ async function rebuild(template: string, model: string, dataString: string): Pro
   // This fails fast on invalid JSON or CTO syntax without running network calls
   await validateBeforeRebuild(template, model, dataString);
   
-  const modelManager = new ModelManager({ strict: true });
+  const modelManager = new ModelManager();
   modelManager.addCTOModel(model, undefined, true);
   await modelManager.updateExternalModels();
-  const engine = new TemplateMarkInterpreter(modelManager, {});
+  // template-engine still publishes v3 Concerto typings; runtime shape is compatible here.
+  const engine = new TemplateMarkInterpreter(modelManager as unknown as never, {});
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
   const templateMarkTransformer = new TemplateMarkTransformer();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -25,7 +25,7 @@ export async function validateBeforeRebuild(
   // 2. Validate CTO model syntax using ModelManager
   // This checks syntax but doesn't load external models (which would require network calls)
   try {
-    const modelManager = new ModelManager({ strict: true });
+    const modelManager = new ModelManager();
     modelManager.addCTOModel(model, undefined, true);
     // Note: We skip updateExternalModels() to avoid expensive network calls
     // We also skip template validation since it may require external models


### PR DESCRIPTION
**Summary**
This PR validates Template Playground against Concerto v4 beta and updates the local integration to use the new ModelManager API shape. It also documents migration steps and issues found during testing so we can share actionable feedback with Concerto maintainers.

**What changed**
- Upgraded top-level Concerto dependency to v4 beta:
 @accordproject/concerto-core -> ^4.0.0-beta.1
- Updated ModelManager usage for v4:
Removed strict constructor option where we create ModelManager instances
- Added a temporary type compatibility workaround at the TemplateMarkInterpreter boundary:
Template engine currently resolves Concerto v3 typings, so a cast is used to keep compile-time compatibility while validating v4 runtime behavior


**Validation performed**
Unit tests: pass (12 files, 75 tests)
Playwright browser installation issue was resolved locally
<img width="761" height="926" alt="Screenshot 2026-03-16 152852" src="https://github.com/user-attachments/assets/b54b83cf-5f01-45b7-a04f-e0215274f42f" />
