### PR TITLE
fix(store): apply shallow equality to Zustand selectors in JSONEditor and MarkdownEditor

### DIFF
--- a/src/editors/JSONEditor.tsx
+++ b/src/editors/JSONEditor.tsx
@@ -1,3 +1,4 @@
+import { shallow } from "zustand/shallow";
 import { lazy, Suspense, useMemo, useCallback, useEffect } from "react";
 import * as monaco from "monaco-editor";
 import useAppStore from "../store/store";
@@ -20,11 +21,14 @@ export default function JSONEditor({
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("json");
 
-  const { backgroundColor, aiConfig, showLineNumbers } = useAppStore((state) => ({
+  const { backgroundColor, aiConfig, showLineNumbers } = useAppStore(
+  (state) => ({
     backgroundColor: state.backgroundColor,
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
-  }));
+  }),
+  shallow
+);
 
   const themeName = useMemo(
     () => (backgroundColor ? "darkTheme" : "lightTheme"),

--- a/src/editors/MarkdownEditor.tsx
+++ b/src/editors/MarkdownEditor.tsx
@@ -1,3 +1,4 @@
+import { shallow } from "zustand/shallow";
 import { lazy, Suspense, useMemo, useCallback, useEffect, MutableRefObject } from "react";
 import useAppStore from "../store/store";
 import { useMonaco } from "@monaco-editor/react";
@@ -23,12 +24,15 @@ export default function MarkdownEditor({
   editorRef?: MutableRefObject<editor.IStandaloneCodeEditor | null>;
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("markdown");
-  const { backgroundColor, textColor, aiConfig, showLineNumbers } = useAppStore((state) => ({
+  const { backgroundColor, textColor, aiConfig, showLineNumbers } = useAppStore(
+  (state) => ({
     backgroundColor: state.backgroundColor,
     textColor: state.textColor,
     aiConfig: state.aiConfig,
     showLineNumbers: state.showLineNumbers,
-  }));
+  }),
+  shallow
+);
   const monaco = useMonaco();
 
   const themeName = useMemo(


### PR DESCRIPTION
Extends the shallow equality optimization from PR #791 to the remaining 
Monaco editors — JSONEditor.tsx and MarkdownEditor.tsx.

Problem
JSONEditor and MarkdownEditor both use object-returning Zustand selectors 
without shallow equality. This returns a new object on every render, causing 
unnecessary re-renders on every keystroke — the same bottleneck that PR #791 
fixed in ConcertoEditor and App.tsx.

Solution
Applied shallow from zustand/shallow to both editors, matching the exact 
pattern established in PR #791.

Files Changed
- src/editors/JSONEditor.tsx
- src/editors/MarkdownEditor.tsx

Testing
- 75/75 tests passing
- No functional changes — performance improvement only

Related
- Extends fix from #791