### PR TITLE
fix(a11y): add keyboard activation to sidebar navigation items

### DIFF
--- a/src/components/PlaygroundSidebar.tsx
+++ b/src/components/PlaygroundSidebar.tsx
@@ -163,6 +163,12 @@ const PlaygroundSidebar = () => {
             aria-label={title}
             tabIndex={0}
             onClick={onClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick?.();
+              }
+            }}
             className={`group playground-sidebar-nav-item ${
               active ? 'playground-sidebar-nav-item-active' : 'playground-sidebar-nav-item-inactive'
             } tour-${title.toLowerCase().replace(' ', '-')}`}
@@ -188,6 +194,12 @@ const PlaygroundSidebar = () => {
             aria-label={title}
             tabIndex={0}
             onClick={onClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick();
+              }
+            }}
             className={`group playground-sidebar-nav-bottom-item tour-${title.toLowerCase().replace(' ', '-')}`}
           >
             <Icon size={18} />


### PR DESCRIPTION
# Closes #842

Sidebar navigation items use role="button" with tabIndex={0}, making
them focusable for keyboard users, but no onKeyDown handler was present.
Pressing Enter or Space did nothing.

### Changes
- Added onKeyDown handler to navTop sidebar items
- Added onKeyDown handler to navBottom sidebar items
- Both handlers trigger onClick on Enter or Space, matching the existing pattern in ProblemPanel.tsx

### Flags
- None

### Screenshots or Video
- N/A (keyboard interaction, not visual change)

### Related Issues
- Issue #842

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the --signoff option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to main from fork:branchname
