### PR TITLE
replace useState with useEffect in useBreakpoint hook to prevent memory leak

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSpring, animated } from "react-spring";
 import { useLocation, Link } from "react-router-dom";
 import {
@@ -172,7 +172,7 @@ const useBreakpoint = () => {
     xl: false,
   });
 
-  useState(() => {
+  useEffect(() => {
     const checkSize = () => {
       setScreenSize({
         sm: window.innerWidth >= 640,
@@ -185,7 +185,7 @@ const useBreakpoint = () => {
     checkSize();
     window.addEventListener('resize', checkSize);
     return () => window.removeEventListener('resize', checkSize);
-  });
+  }, []);
 
   return screenSize;
 };


### PR DESCRIPTION

Fixes #850 

### Description

The custom [useBreakpoint](cci:1://file:///c:/Users/DIVYANSH%20RAI/Downloads/template-playground123/src/components/Navbar.tsx:166:0-190:2) hook in [Navbar.tsx](cci:7://file:///c:/Users/DIVYANSH%20RAI/Downloads/template-playground123/src/components/Navbar.tsx:0:0-0:0) was incorrectly using `useState` to register a `window.addEventListener('resize', ...)` side-effect. React's `useState` initializer runs once but **silently discards** any return value, meaning the cleanup function (`removeEventListener`) was never called.

This caused:
- **Memory leak**: Orphaned `resize` listeners accumulated on every component remount (e.g., route navigation).
- **React Strict Mode issues**: In development, Strict Mode double-mounts components, doubling the leaked listeners with no cleanup.

### Changes Made

| File | Change |
|------|--------|
| [src/components/Navbar.tsx](cci:7://file:///c:/Users/DIVYANSH%20RAI/Downloads/template-playground123/src/components/Navbar.tsx:0:0-0:0) | Replaced `useState` with `useEffect` (+ empty `[]` deps) in the [useBreakpoint](cci:1://file:///c:/Users/DIVYANSH%20RAI/Downloads/template-playground123/src/components/Navbar.tsx:166:0-190:2) hook |

### Before (Bug)
```tsx
useState(() => {
  // ...
  window.addEventListener('resize', checkSize);
  return () => window.removeEventListener('resize', checkSize); // ← never called
});
```

### After (Fix)
```tsx
useEffect(() => {
  // ...
  window.addEventListener('resize', checkSize);
  return () => window.removeEventListener('resize', checkSize); // ← properly cleaned up
}, []);
```

### How to Test

1. Open the app and navigate between `/` and `/learn/intro` multiple times.
2. Open DevTools → **Performance Monitor** → check "Event Listeners" count.
3. **Before fix**: listener count increases with each navigation.
4. **After fix**: listener count stays stable.

### Checklist

- [x] Code follows the project's style guidelines
- [x] No new dependencies added
- [x] Change is backward-compatible
- [x] Tested locally responsive Navbar behavior works as expected
