### PR TITLE
fix(ai): update Google Generative Language API endpoint to v1beta

### DIFF
--- a/src/components/AIConfigPopup.tsx
+++ b/src/components/AIConfigPopup.tsx
@@ -192,7 +192,7 @@ const AIConfigPopup = ({ isOpen, onClose }: AIConfigPopupProps) => {
           case 'google':
             if (!apiKey) return;
             {
-              const res = await fetch('https://generativelanguage.googleapis.com/v1beta2/models', {
+              const res = await fetch('https://generativelanguage.googleapis.com/v1beta/models', {
                 headers: { 'x-goog-api-key': apiKey },
                 signal,
               });


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #854 
<!--- Provide an overall summary of the pull request -->

### Changes
- Updated Google Generative Language API fetch URL from deprecated `v1beta2` to current `v1beta` in [AIConfigPopup.tsx]

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Single-line change, no logic affected
- Only impacts Google provider model-list fetching; all other providers unchanged


### Screenshots or Video
Before: Model dropdown shows "No models available" for Google provider  
<img width="464" height="637" alt="image" src="https://github.com/user-attachments/assets/7dbf9f8b-a4ad-483f-b956-4bd0f35c51e4" />


After: Model dropdown correctly lists available Gemini models
<img width="456" height="875" alt="image" src="https://github.com/user-attachments/assets/6a239b7b-f7eb-40cf-8ed5-0a0713f20402" />


### Related Issues
- Issue #854 

### Author Checklist
- [X] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [X] Vital features and changes captured in unit and/or integration tests
- [X] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [X] Extend the documentation, if necessary
- [X] Merging to `main` from `fix/google-ai-endpoint`
