### PR TITLE
test(playground): fix TipTap regression test build on mr-template-editor

### DIFF
--- a/src/tests/components/TiptapTemplateEditor.test.tsx
+++ b/src/tests/components/TiptapTemplateEditor.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { describe, it, beforeEach, expect, vi } from "vitest";
+import { ModelManager } from "@accordproject/concerto-core";
 import TiptapTemplateEditor from "../../editors/TiptapTemplateEditor";
 import useAppStore from "../../store/store";
 
@@ -34,7 +35,7 @@ describe("TiptapTemplateEditor", () => {
 
   it("retries parsing when modelManager changes after an external markdown load", async () => {
     const loadedMarkdown = "Loaded sample markdown";
-    const modelManager = { id: "new-model-manager" };
+    const modelManager = new ModelManager({ strict: true });
     const parsedDoc = {
       $class: "org.accordproject.commonmark@0.5.0.Document",
       nodes: [],


### PR DESCRIPTION
# Closes N/A

Restores the Netlify/build pipeline on `mr-template-editor` after the new TipTap regression test introduced a TypeScript build failure.

This PR addresses a follow-up issue from PR #878 where `src/tests/components/TiptapTemplateEditor.test.tsx` stored a plain object in `modelManager`. That worked in the mocked Vitest path, but failed `tsc` because the Zustand store expects a real `ModelManager` instance. As a result, `npm run build` failed and the Netlify deploy checks could not complete successfully.

### Changes

- Updated `src/tests/components/TiptapTemplateEditor.test.tsx` to use a real `ModelManager` instance instead of a plain `{ id: string }` object.
- Kept the fix scoped to the regression test only, without changing `TiptapTemplateEditor`, store behavior, or any user-facing runtime flow.
- Re-ran local verification with:
  - `npm run build`
  - `npx vitest run src/tests/components/TiptapTemplateEditor.test.tsx`
  - `npx vitest run src/tests/store/setData.test.tsx`
  - `npm run test:unit`

### Flags

- This PR intentionally keeps the fix scoped to the present `mr-template-editor` build regression rather than broadening into runtime/editor changes from PR #878.
- Backup-branch differences in `vite.config.ts` and the rebuild/model-loading path were reviewed, but no broader rollback was needed once the TypeScript test failure was fixed.
- No screenshots or video are included because this is a build/test fix rather than a visual UI change.

### Screenshots or Video

N/A - this is a build/test fix. The behavior is covered by build and unit test verification rather than a visual UI change.

### Related Issues

- Pull Request #878

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `mr-template-editor` from `fork:branchname`
