### PR TITLE
fix(ui): theme Settings modal subtree to make text legible in dark mode

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { Modal, Switch, Collapse, Space, Divider, Typography, Row, Col } from 'antd';
+import { Modal, Switch, Collapse, Space, Divider, Typography, ConfigProvider, theme, Row, Col } from 'antd';
 import { BulbOutlined, MoonOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons';
 import useAppStore from '../store/store';
 import AIConfigSection from './AIConfigSection';
+import { colors } from '../utils/theme';
 
 const { Text } = Typography;
 
@@ -114,23 +115,30 @@ const SettingsModal: React.FC = () => {
   ];
 
   return (
-    <Modal
-      title="Settings"
-      open={isSettingsOpen}
-      onCancel={() => setSettingsOpen(false)}
-      footer={null}
-      className={isDarkMode ? 'dark-modal' : ''}
-      width="90%"
-      style={{ maxWidth: 520 }}
+    <ConfigProvider
+      theme={{
+        algorithm: isDarkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
+        token: {
+          colorPrimary: colors.primary,
+        },
+      }}
     >
-      <Collapse
-        activeKey={activeKey}
-        onChange={setActiveKey}
-        items={collapseItems}
-        bordered={false}
-        className={isDarkMode ? 'dark-collapse' : ''}
-      />
-    </Modal>
+      <Modal
+        title="Settings"
+        open={isSettingsOpen}
+        onCancel={() => setSettingsOpen(false)}
+        footer={null}
+        width="90%"
+        style={{ maxWidth: 520 }}
+      >
+        <Collapse
+          activeKey={activeKey}
+          onChange={setActiveKey}
+          items={collapseItems}
+          bordered={false}
+        />
+      </Modal>
+    </ConfigProvider>
   );
 };
 


### PR DESCRIPTION
# Closes #892

The Settings modal renders AntD components (`Modal`, `Collapse`, `Typography.Text`, `Form`, `Select`, `Input`, `Checkbox`, `Switch`, `Divider`, `Button`) without any AntD theme configuration, so it always uses AntD's default light tokens. When the playground is switched to dark mode, the modal background goes dark via CSS but the text colours stay dark, leaving labels and especially `Text type="secondary"` descriptions illegible against the dark background.

While verifying the issue, I confirmed the same problem extends to the **AI Configuration** panel inside the same modal. Once expanded, all of its form labels, hint text, secondary descriptions for the checkboxes (Show Full Prompts, Enable Code Selection Menu, Enable Inline AI Suggestions), and the Save / Reset buttons inherit the same broken light tokens. So the bug was wider than just the two visible labels in the screenshot on the issue. This PR fixes both the General panel and the AI Configuration panel together.

The fix wraps the modal subtree in `ConfigProvider` with `theme.darkAlgorithm` when dark mode is active. This is AntD's officially supported dark-mode mechanism and themes every descendant component automatically, including anything added to the modal in the future.

The `colorPrimary` token is pinned to `colors.primary` from `src/utils/theme.ts` so the playground's teal accent (`#19c6c7`) flows through Switches, focus rings, primary buttons (e.g. "Save Configuration"), and links, rather than reverting to AntD's default blue.

The conditional `dark-modal` and `dark-collapse` className props were no-ops (no CSS in the repo targeted either class) and were removed in this commit, since `ConfigProvider` correctly replaces their intent.

### Changes
- `src/components/SettingsModal.tsx`: wrap the `<Modal />` subtree in `ConfigProvider` with `theme.darkAlgorithm` / `theme.defaultAlgorithm` based on `isDarkMode`, and override `colorPrimary` with `colors.primary` from the brand-colour module to preserve the playground's teal accent.
- `src/components/SettingsModal.tsx`: remove the unused `dark-modal` and `dark-collapse` class names.

## Flags
- No CSS files are touched, no global styles introduced.
- The existing `html[data-theme="dark"] .ant-modal-confirm` rules in `src/index.css` for the sample-template confirmation modal are not affected. That modal is rendered imperatively via `Modal.confirm()` outside this `ConfigProvider`, so it continues to use the existing CSS-based overrides.
- `AIConfigSection.tsx` is intentionally not modified. It inherits the dark theme automatically because it is rendered as a descendant of the modal subtree. This is the maintainability win of using `ConfigProvider` rather than hand-written class-name CSS.

## Screenshots

### Before
<img width="1919" height="906" alt="image" src="https://github.com/user-attachments/assets/1ad34d2a-f232-4d77-b16f-df823f554003" />


### After
<img width="1904" height="912" alt="image" src="https://github.com/user-attachments/assets/a8572d72-6aaf-4121-845e-6b8e2350db74" />

### Related Issues
- Issue #892

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
