### PR TITLE
feat(model): bundle accordproject.money and accordproject.obligation

### DIFF
--- a/src/models/bundled/accordproject.money.cto
+++ b/src/models/bundled/accordproject.money.cto
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+concerto version "^3.0.0"
+
+namespace org.accordproject.money@0.3.0
+
+/**
+ * Represents an amount of Cryptocurrency
+ */
+concept DigitalMonetaryAmount {
+  o Double doubleValue
+  o DigitalCurrencyCode digitalCurrencyCode
+}
+
+/**
+ * Digital Currency codes. From https://en.wikipedia.org/wiki/List_of_cryptocurrencies
+ */
+enum DigitalCurrencyCode {
+  o ADA
+  o BCH
+  o BTC
+  o DASH
+  o EOS
+  o ETC
+  o ETH
+  o LTC
+  o NEO
+  o XLM
+  o XMR
+  o XRP
+  o ZEC
+}
+
+/**
+ * Represents an amount of money
+ */
+concept MonetaryAmount {
+  o Double doubleValue // convert to fixed-point?
+  o CurrencyCode currencyCode
+}
+
+/**
+ * ISO 4217 codes. From https://en.wikipedia.org/wiki/ISO_4217
+ * https://www.currency-iso.org/en/home/tables/table-a1.html
+ */
+enum CurrencyCode {
+o AED
+o AFN
+o ALL
+o AMD
+o ANG
+o AOA
+o ARS
+o AUD
+o AWG
+o AZN
+o BAM
+o BBD
+o BDT
+o BGN
+o BHD
+o BIF
+o BMD
+o BND
+o BOB
+o BOV
+o BRL
+o BSD
+o BTN
+o BWP
+o BYN
+o BZD
+o CAD
+o CDF
+o CHE
+o CHF
+o CHW
+o CLF
+o CLP
+o CNY
+o COP
+o COU
+o CRC
+o CUC
+o CUP
+o CVE
+o CZK
+o DJF
+o DKK
+o DOP
+o DZD
+o EGP
+o ERN
+o ETB
+o EUR
+o FJD
+o FKP
+o GBP
+o GEL
+o GHS
+o GIP
+o GMD
+o GNF
+o GTQ
+o GYD
+o HKD
+o HNL
+o HRK
+o HTG
+o HUF
+o IDR
+o ILS
+o INR
+o IQD
+o IRR
+o ISK
+o JMD
+o JOD
+o JPY
+o KES
+o KGS
+o KHR
+o KMF
+o KPW
+o KRW
+o KWD
+o KYD
+o KZT
+o LAK
+o LBP
+o LKR
+o LRD
+o LSL
+o LYD
+o MAD
+o MDL
+o MGA
+o MKD
+o MMK
+o MNT
+o MOP
+o MRU
+o MUR
+o MVR
+o MWK
+o MXN
+o MXV
+o MYR
+o MZN
+o NAD
+o NGN
+o NIO
+o NOK
+o NPR
+o NZD
+o OMR
+o PAB
+o PEN
+o PGK
+o PHP
+o PKR
+o PLN
+o PYG
+o QAR
+o RON
+o RSD
+o RUB
+o RWF
+o SAR
+o SBD
+o SCR
+o SDG
+o SEK
+o SGD
+o SHP
+o SLL
+o SOS
+o SRD
+o SSP
+o STN
+o SVC
+o SYP
+o SZL
+o THB
+o TJS
+o TMT
+o TND
+o TOP
+o TRY
+o TTD
+o TWD
+o TZS
+o UAH
+o UGX
+o USD
+o USN
+o UYI
+o UYU
+o UZS
+o VEF
+o VND
+o VUV
+o WST
+o XAF
+o XAG
+o XAU
+o XBA
+o XBB
+o XBC
+o XBD
+o XCD
+o XDR
+o XOF
+o XPD
+o XPF
+o XPT
+o XSU
+o XTS
+o XUA
+o XXX
+o YER
+o ZAR
+o ZMW
+o ZWL
+}
+
+/**
+ * Represents a currency conversion pair and exchange rate
+ */
+concept CurrencyConversion {
+   o CurrencyCode from
+   o CurrencyCode to
+   o Double rate
+}

--- a/src/models/bundled/accordproject.obligation.cto
+++ b/src/models/bundled/accordproject.obligation.cto
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+concerto version "^3.0.0"
+
+namespace org.accordproject.obligation@0.2.0
+
+import org.accordproject.runtime@0.2.0.Obligation from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
+
+/**
+ * Useful Obligations
+ * -- Predefined obligations for general use in Accord Project templates
+ */
+
+event PaymentObligation extends Obligation {
+  o MonetaryAmount amount
+  o String description
+}
+
+event NotificationObligation extends Obligation {
+  o String title
+  o String message
+}

--- a/src/utils/modelCache.test.ts
+++ b/src/utils/modelCache.test.ts
@@ -17,6 +17,8 @@ describe("loadBundledModels", () => {
         "com.docusign.connect@0.4.0",
         "org.accordproject.binary@0.2.0",
         "org.accordproject.contract@0.2.0",
+        "org.accordproject.money@0.3.0",
+        "org.accordproject.obligation@0.2.0",
         "org.accordproject.runtime@0.2.0",
         "org.accordproject.signature@0.3.0",
         "org.accordproject.time@0.3.0",

--- a/src/utils/modelCache.ts
+++ b/src/utils/modelCache.ts
@@ -3,6 +3,8 @@
 import contractCto from "../models/bundled/accordproject.contract.cto?raw";
 import runtimeCto from "../models/bundled/accordproject.runtime.cto?raw";
 import timeCto from "../models/bundled/accordproject.time.cto?raw";
+import moneyCto from "../models/bundled/accordproject.money.cto?raw";
+import obligationCto from "../models/bundled/accordproject.obligation.cto?raw";
 import binaryCto from "../models/bundled/accordproject.binary.cto?raw";
 import signatureCto from "../models/bundled/accordproject.signature.cto?raw";
 import docusignConnectCto from "../models/bundled/docusign.connect.cto?raw";
@@ -30,6 +32,16 @@ const BUNDLED_MODELS: BundledModel[] = [
     namespace: "org.accordproject.time@0.3.0",
     fileName: "@models.accordproject.org.time@0.3.0.cto",
     source: timeCto,
+  },
+  {
+    namespace: "org.accordproject.money@0.3.0",
+    fileName: "@models.accordproject.org.money@0.3.0.cto",
+    source: moneyCto,
+  },
+  {
+    namespace: "org.accordproject.obligation@0.2.0",
+    fileName: "@models.accordproject.org.accordproject.obligation@0.2.0.cto",
+    source: obligationCto,
   },
   {
     namespace: "org.accordproject.binary@0.2.0",


### PR DESCRIPTION
## Summary

Follow-up to [#919](https://github.com/accordproject/template-playground/pull/919). Adds two more Accord Project standard namespaces to the offline bundle so templates importing them resolve without network access:

- \`org.accordproject.money@0.3.0\`
- \`org.accordproject.obligation@0.2.0\`

These two are referenced by several templates in [\`accordproject/cicero-template-library\`](https://github.com/accordproject/cicero-template-library) (e.g. anything that uses \`MonetaryAmount\` or the runtime obligation hierarchy) and were not in the initial bundle.

## What changed

- New pinned snapshots in \`src/models/bundled/\`:
  - \`accordproject.money.cto\` — fetched from \`https://models.accordproject.org/money@0.3.0.cto\`.
  - \`accordproject.obligation.cto\` — fetched from \`https://models.accordproject.org/accordproject/obligation@0.2.0.cto\`.
- \`src/utils/modelCache.ts\` — register the two new \`BundledModel\` entries. The loader, validator and rebuild paths pick them up automatically.
- \`src/utils/modelCache.test.ts\` — extend the namespace-list assertion to cover the new entries.

No other code changes.

## Test plan

- [x] \`npx tsc --noEmit\` — clean.
- [x] \`npm run test\` for the two affected test files — 8/8 pass (\`modelCache.test.ts\` + \`validators.test.ts\`).
- [ ] Reviewer: paste a template that imports \`org.accordproject.money@0.3.0\` or \`org.accordproject.obligation@0.2.0\` into the playground and confirm it compiles without network access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)