### PR TITLE
chore(deps): upgrade to template-engine 4 / markdown-transform 1.0 / concerto 4.1

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ The Accord Project Playground is an open-source project, welcoming contributions
 - **Functionality Enhancements:** Improve existing features based on user feedback and project needs.
 - **Documentation and Tutorials:** Contribute to comprehensive documentation and tutorials that guide users through the platform effectively.
 
+## Local Development
+
+**Prerequisites:** Node.js >= 22 (required by the Accord Project dependencies —
+`@accordproject/template-engine` 4.x, `markdown-transform` / `concerto` 4.x).
+
+```bash
+npm install        # install dependencies
+npm run dev        # start the dev server (http://localhost:5173)
+npm run test:unit  # unit tests (vitest)
+npm run test:e2e   # browser end-to-end tests (Playwright)
+npm run build      # type-check + production build
+```
+
+The playground runs the [Template-Engine](https://github.com/accordproject/template-engine)
+**in the browser** — TemplateMark templates (including their TypeScript logic) are type-checked,
+compiled, and evaluated client-side to produce the live agreement preview.
+
 ## Demo
 
 The Template Playground is deployed at: [https://playground.accordproject.org](https://playground.accordproject.org)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "template_playground",
       "version": "0.0.0",
       "dependencies": {
-        "@accordproject/concerto-core": "^3.25.7",
-        "@accordproject/concerto-cto": "^3.25.7",
-        "@accordproject/markdown-common": "^0.17.2",
-        "@accordproject/markdown-template": "^0.17.2",
-        "@accordproject/markdown-transform": "^0.17.2",
-        "@accordproject/template-engine": "^2.8.0",
+        "@accordproject/concerto-core": "^4.1.4",
+        "@accordproject/concerto-cto": "^4.1.4",
+        "@accordproject/markdown-common": "^1.0.1",
+        "@accordproject/markdown-template": "^1.0.1",
+        "@accordproject/markdown-transform": "^1.0.1",
+        "@accordproject/template-engine": "^4.0.0",
         "@ant-design/icons": "^5.3.7",
         "@anthropic-ai/sdk": "^0.56.0",
         "@google/genai": "^1.8.0",
@@ -107,31 +107,34 @@
       }
     },
     "node_modules/@accordproject/cicero-core": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.25.2.tgz",
-      "integrity": "sha512-mx8moSOcJl+CWs8fXEIzGRM8sbw+heClWa3Zf6SCroTpidT7iZFhSehfq1LMTIgzadEc78Rcd+PWs9n9wdaafw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-1.0.1.tgz",
+      "integrity": "sha512-19b8c7B3gN6r5SnmevGdKTlXA0Lagf7tyhJoLBF/EAVN5OWx+hO8Fff07dp/wVQ/Ked9wVLkyhje+qGVu31wmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/concerto-util": "3.25.7",
-        "@accordproject/markdown-cicero": "0.17.2",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-template": "0.17.2",
-        "@accordproject/markdown-transform": "0.17.2",
-        "@types/node": "^22.13.13",
-        "axios": "1.13.6",
+        "@accordproject/concerto-core": "4.1.4",
+        "@accordproject/concerto-util": "4.1.4",
+        "@accordproject/markdown-cicero": "1.0.1",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-template": "1.0.1",
+        "@accordproject/markdown-transform": "1.0.1",
+        "axios": "1.15.0",
         "debug": "4.3.4",
         "ietf-language-tag-regex": "0.0.5",
         "json-stable-stringify": "1.0.2",
         "jszip": "3.10.1",
         "node-cache": "5.1.2",
+        "node-forge": "^1.4.0",
         "semver": "7.5.3",
         "slash": "3.0.0",
         "xregexp": "5.1.1"
       },
       "engines": {
-        "node": ">=20",
+        "node": ">=22",
         "npm": ">=10"
+      },
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3"
       }
     },
     "node_modules/@accordproject/cicero-core/node_modules/lru-cache": {
@@ -168,14 +171,11 @@
       "license": "ISC"
     },
     "node_modules/@accordproject/concerto-codegen": {
-      "version": "3.32.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-3.32.1.tgz",
-      "integrity": "sha512-nVFCTUk/i37dm5zdfteZtCf/okinVFEX/+V6lO3Jsc7NIWrU9CPP8KAqhG1nB+3Rsqmg3qt7BQT0xe5dMyFnHQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-4.1.3.tgz",
+      "integrity": "sha512-a1OvKHIFNnJNJ0+AxgWIG4RAe7PQ+P0CJZufu4f+6YIeaEDHln5Y7uBcnnXFVMc76XbnKXteLdmVBuIPjG+DDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.0",
-        "@accordproject/concerto-util": "3.25.0",
-        "@accordproject/concerto-vocabulary": "3.25.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "4.0.0",
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
@@ -188,93 +188,11 @@
       "engines": {
         "node": ">=18",
         "npm": ">=6"
-      }
-    },
-    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-core": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.0.tgz",
-      "integrity": "sha512-A/Zr4bFTYjWkVEVZCvQadLk08sT5oAx3ED/674lq89vC6Ml/mwopym8JKKszIF5oq8TOMzLhRrxpdLfI3rIQSg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "3.25.0",
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.0",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "^2.8.0"
       },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-core/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-cto": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.25.0.tgz",
-      "integrity": "sha512-WVPyHYBEg1vwVCH6lOu+7BfNSeRuuV/Tli5CLZI9NPCcI2i/QWWBm6aEs02KnNiC++YTpGK6huvL6n6rz/0Wmg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-util": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.0.tgz",
-      "integrity": "sha512-TNUcM+Tb+J26K6FZDC44WOUt1S7e17fn6oVe4UaYpaZPY4kg64YbHg1sUkIioiDFtamOMoJDyBeKoPLMi1BDOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-codegen/node_modules/@accordproject/concerto-util/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3",
+        "@accordproject/concerto-util": "^4.1.3",
+        "@accordproject/concerto-vocabulary": "^4.1.3"
       }
     },
     "node_modules/@accordproject/concerto-codegen/node_modules/ajv-formats": {
@@ -294,33 +212,15 @@
         }
       }
     },
-    "node_modules/@accordproject/concerto-codegen/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/concerto-codegen/node_modules/uuid": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@accordproject/concerto-core": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-3.25.7.tgz",
-      "integrity": "sha512-9bMvZLvSyhpbnhirG60ocmjgeej6bTXCrKvavN+919pO5Hsfpqd0cSjevjglxe0V58Jt6gDUWb+bN3pEQg442g==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.4.tgz",
+      "integrity": "sha512-Fc0S/+jQUPxouhN/onRoVjSV+WYm/yjCzKN3JEM0mzV8lHXBtLOR6SQtOfJC8Ott0JIySKI9J4QtBKpicIHdQw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7",
+        "@accordproject/concerto-cto": "4.1.4",
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.4",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
@@ -329,11 +229,11 @@
         "semver": "7.6.3",
         "urijs": "1.19.11",
         "uuid": "11.0.3",
-        "yaml": "2.8.0"
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/concerto-core/node_modules/debug": {
@@ -370,279 +270,128 @@
       }
     },
     "node_modules/@accordproject/concerto-cto": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-3.25.7.tgz",
-      "integrity": "sha512-99VUBCW8ye/wMNukmt5PHcCC3zG6RTwHAcVixLjVO/RJFiMDXZMdfYiH750dxyGfb3sbTK36pZn3Bu809o9ISw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.4.tgz",
+      "integrity": "sha512-ZA5naXqHdX2FcdMIM5945/wIO+CzqG8beGzB1sqKNwsbEutjin+NQW/VM+gjqplWITR3ZR6b8tsIu/Q0jU5RMw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "@accordproject/concerto-util": "3.25.7"
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.4",
+        "acorn": "^8.15.0",
+        "path-browserify": "^1.0.1",
+        "schema-utils": "^4.3.3"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.12.6",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.12.6.tgz",
-      "integrity": "sha512-GGkD5H89dUt4Z6CyP+ozFMYEYrKyCq9QHYV3DcyyJY9q3tGGr+elvGJqUoC20ljZaE6HV0GPar54GTMDEmh6pw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.1.tgz",
+      "integrity": "sha512-af8mpDuHGSfBH+VlVRwBqhiBVrLI0srRslT44Q4hkZJJHHnxU5K5U2wznGamazP1FMXLnOwXiFG4ZMudAll7Vw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14",
         "npm": ">=6"
       }
     },
     "node_modules/@accordproject/concerto-util": {
-      "version": "3.25.7",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-3.25.7.tgz",
-      "integrity": "sha512-1Ccta2Kx4DixydX7+/WtWkDm7y1fP6BzQHxx6bS1qh2pEychs2njGw8GZiV7skzYc8YJhidngbWGZ7vTZSoRbA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.4.tgz",
+      "integrity": "sha512-FifiXZkUIZisSxG6AJ9ORR/+EULHKxk9qeW69pffLei+WpmSUJDFSp4gHiW8hb11Z46IXO+/9RqdcJfXYI43eA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
-        "debug": "4.3.7",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
         "slash": "3.0.0"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
-    },
-    "node_modules/@accordproject/concerto-util/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/concerto-util/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@accordproject/concerto-vocabulary": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-3.25.0.tgz",
-      "integrity": "sha512-WrnSMSQAFuJhFpH6h+4oN1UOcBbZEl8zXpugkHUYG5EMeQWu41g1M3OAqYzr8oVQV7bUEH05EDcgBClzAUJuPQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-vocabulary/-/concerto-vocabulary-4.1.4.tgz",
+      "integrity": "sha512-MYCpIKLBK0/yNTM2cJcRrKLPhzJr6hSU90t852VmT66aoykQm+oh0Eh3nN9s3Zd8+t4mMY/9svP8+T0vnxKrnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-metamodel": "3.12.6",
-        "yaml": "2.6.1"
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "yaml": "2.8.3"
       },
       "engines": {
         "node": ">=18",
-        "npm": ">=10"
+        "npm": ">=9"
       }
     },
     "node_modules/@accordproject/concerto-vocabulary/node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@accordproject/markdown-cicero": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.17.2.tgz",
-      "integrity": "sha512-SL/D5s0a5thydsHX/0hfrZqxgh1/R3ikJD+LcH7iRy2DcMFCKh2N74LcGleLdsCB78aT8aDkgFA/F01NAx5t6w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-1.0.1.tgz",
+      "integrity": "sha512-+S5lJA1g2+CHJ6qvA3kaQEO8GU9rH7KU7wLniQQVq1TbAFri+sAglKj3lN1bo4kIpUIQJ3SKQK5w+TmVSa2aJQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-it-cicero": "0.17.2",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-it-cicero": "1.0.1",
         "markdown-it": "^14.1.0",
         "semver": "7.6.3",
         "winston": "3.17.0"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
       },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/one-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-      "dependencies": {
-        "fn.name": "1.x.x"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
-    },
-    "node_modules/@accordproject/markdown-cicero/node_modules/winston": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
-      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.7.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.2"
       }
     },
     "node_modules/@accordproject/markdown-common": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.17.2.tgz",
-      "integrity": "sha512-OmpPp7uDLSO5odjhhTThjJjK7zCB2uuR/bGnalWLJwhfJrITo8JyvAYS+61DfHocuxVH1sHQg5NVnsEoqwIdeg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-1.0.1.tgz",
+      "integrity": "sha512-3ZpZZaGDB7FVQiv7SWjsAtb7mnkHDUxoH74iYxEzoWQxL89C6qMSXRecmP+CGA5jPxbSsOspjiPYZDqrQPHgxw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@xmldom/xmldom": "^0.9.5",
+        "@xmldom/xmldom": "^0.9.10",
         "markdown-it": "^14.1.0"
       },
       "engines": {
-        "node": ">=15",
+        "node": ">=22",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
       },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3"
       }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
-    },
-    "node_modules/@accordproject/markdown-common/node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/@accordproject/markdown-html": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.17.2.tgz",
-      "integrity": "sha512-OonOpU/BA6gIf3xYrDaa0gB7jKEoniNVrfOEq9dag/7ZoGVdKTMtK16CKC75avuzgAxLZyNXsU50dNzAS5sWdg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-1.0.1.tgz",
+      "integrity": "sha512-WZDHTrlJUdi9sd3VrwnLBZGkcr+qi1ShpUIGmcFWFw+lUOw2kENROGX1CZJnnhuboFQrZMsgvZAvBuqJfhn96Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/markdown-cicero": "0.17.2",
-        "@accordproject/markdown-common": "0.17.2",
+        "@accordproject/markdown-cicero": "1.0.1",
+        "@accordproject/markdown-common": "1.0.1",
         "jsdom": "^25.0.1",
+        "process": "^0.11.10",
         "type-of": "^2.0.1"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
       }
     },
@@ -650,6 +399,7 @@
       "version": "25.0.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -685,15 +435,11 @@
         }
       }
     },
-    "node_modules/@accordproject/markdown-html/node_modules/rrweb-cssom": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="
-    },
     "node_modules/@accordproject/markdown-html/node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
       },
@@ -702,212 +448,91 @@
       }
     },
     "node_modules/@accordproject/markdown-it-cicero": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.17.2.tgz",
-      "integrity": "sha512-I1csdMEhgyW4uiZlVubKknP0E64Qdz8d44FD9+dqWhVS+btwV6/X6TxNuMaTXVIyPw3RN9l4ZJRYcT6FO7MLoQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-1.0.1.tgz",
+      "integrity": "sha512-6cgDtb9/OJtWb0fzNsRsKWPdnOSeklfQMn371i8B3mnFI5pj7SQplyQUlTe6DGjYFP4BWmslV8VHKywa+uhuKA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "markdown-it": "^14.1.0"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
       }
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
-    },
-    "node_modules/@accordproject/markdown-it-cicero/node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/@accordproject/markdown-it-template": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.17.2.tgz",
-      "integrity": "sha512-3BANEXlGaRUpo/FoTPmD9uhdmcGRS6dkkJTw02iiuiokCoiz5uwbo+HWqsQO9HUS2ucVn2CXYM+GjgaNQRPAMQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-1.0.1.tgz",
+      "integrity": "sha512-I8Op+r3ZCEBuHrL2URn/hxxP0Gss66cWjn30/E4uVbZS6Jf3K0YeQWSWTpvLwxeFVQBn50MiXaTs89e+KHFl/Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "markdown-it": "^14.1.0"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
       }
-    },
-    "node_modules/@accordproject/markdown-it-template/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-template/node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-template/node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/@accordproject/markdown-it-template/node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
-    },
-    "node_modules/@accordproject/markdown-it-template/node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/@accordproject/markdown-template": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.17.2.tgz",
-      "integrity": "sha512-N7zFBCixTgUD/ZRz581pF00HfLcSK17YNvv864RRsmQyM4VFIgD56Us9G6JuHXaHy+gdr7fkWT/gjhCmbHH5vg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-1.0.1.tgz",
+      "integrity": "sha512-P1yEXbtUdSwUS/PbDKWms41etpa/gjD7PfWlXiotE0F2IglgHZfAjzWh5/elpdwXSY54rLpOH2JK9edpyZrSwQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/concerto-cto": "3.25.7",
-        "@accordproject/markdown-cicero": "0.17.2",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-it-template": "0.17.2",
+        "@accordproject/markdown-cicero": "1.0.1",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-it-template": "1.0.1",
         "dayjs": "1.11.13",
-        "markdown-it": "^14.1.0"
+        "markdown-it": "^14.1.0",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
       },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3",
+        "@accordproject/concerto-cto": "^4.1.3"
       }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
-    },
-    "node_modules/@accordproject/markdown-template/node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/@accordproject/markdown-transform": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.17.2.tgz",
-      "integrity": "sha512-6cjrwwJI/oiIiP4Q6WfjZBaVIuh0qmDIJs0Y5zDLBzcDvPRJvJM2ete9DwjZVYx6Dd9hW4a0A60lu2wuLk+Yng==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-1.0.1.tgz",
+      "integrity": "sha512-gth7Nz34DPhSvoh4IxxMZK6ZfcvHRMdSGYW9/0z4Ohau46lyMpUMudoRU+EsYh9ELjAdosoBgrg3ac3zFHi/xw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/markdown-cicero": "0.17.2",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-html": "0.17.2",
-        "@accordproject/markdown-template": "0.17.2",
+        "@accordproject/markdown-cicero": "1.0.1",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-html": "1.0.1",
+        "@accordproject/markdown-template": "1.0.1",
         "dijkstrajs": "^1.0.3",
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=22",
         "npm": ">=9"
+      },
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3"
       }
     },
     "node_modules/@accordproject/template-engine": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/template-engine/-/template-engine-2.9.0.tgz",
-      "integrity": "sha512-IhWIgznhzj7WmrzVdLvTWfxjoPlcW6Iyql2rdxJ0Fqv0LI2c7XvaUncyq2gHundqp2WRsKjwoALL7i2U4vAGSg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/template-engine/-/template-engine-4.0.0.tgz",
+      "integrity": "sha512-2MNwgK/Cp7iFmvmmYODflUX7yMkUHSjdEF03ZjBcoAxGJdASrGnWgnL/SSdK7kBnCiH87wa3i9GuXZJXnnMi1Q==",
       "license": "Apache-2.0",
+      "workspaces": [
+        "e2e"
+      ],
       "dependencies": {
-        "@accordproject/cicero-core": "0.25.2",
-        "@accordproject/concerto-codegen": "3.32.1",
-        "@accordproject/concerto-core": "3.25.7",
-        "@accordproject/concerto-util": "3.25.7",
-        "@accordproject/markdown-common": "0.17.2",
-        "@accordproject/markdown-template": "0.17.2",
+        "@accordproject/cicero-core": "1.0.1",
+        "@accordproject/concerto-codegen": "4.1.3",
+        "@accordproject/concerto-core": "4.1.4",
+        "@accordproject/concerto-util": "4.1.4",
+        "@accordproject/concerto-vocabulary": "4.1.4",
+        "@accordproject/markdown-common": "1.0.1",
+        "@accordproject/markdown-template": "1.0.1",
         "@typescript/twoslash": "^3.2.9",
         "browser-or-node": "^3.0.0",
         "dayjs": "1.11.13",
@@ -918,11 +543,8 @@
         "typescript": "^5.8.2"
       },
       "engines": {
-        "node": ">=20",
+        "node": ">=22",
         "npm": ">=6"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.38.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2827,9 +2449,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
       "license": "MIT",
       "dependencies": {
         "core-js-pure": "^3.48.0"
@@ -2885,6 +2507,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -3006,21 +2629,12 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
       "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
       "dependencies": {
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
-    },
-    "node_modules/@dabh/diagnostics/node_modules/enabled": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
-    },
-    "node_modules/@dabh/diagnostics/node_modules/kuler": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
@@ -5177,6 +4791,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5314,57 +4929,17 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
       "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
       "dependencies": {
         "color": "^5.0.2",
         "text-hex": "1.0.x"
-      }
-    },
-    "node_modules/@so-ric/colorspace/node_modules/color": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
-      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
-      "dependencies": {
-        "color-convert": "^3.1.3",
-        "color-string": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@so-ric/colorspace/node_modules/color-convert": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
-      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
-    "node_modules/@so-ric/colorspace/node_modules/color-name": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/@so-ric/colorspace/node_modules/color-string": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
-      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@supercharge/promise-pool": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-1.7.0.tgz",
       "integrity": "sha512-OpnF7oqk6asrOUMhldnDju4RKeZ/iMAfw3LIoLdcTI53RZJLiQ9vEAcGW+bcBELXkiPhT7RqtuPSXAFF2iAmbg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5703,7 +5278,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lz-string": {
@@ -5829,9 +5403,10 @@
       }
     },
     "node_modules/@types/triple-beam": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
-      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g=="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -6595,7 +6170,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -6612,7 +6186,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -6855,6 +6428,12 @@
         "node": "*"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -6927,14 +6506,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -7828,6 +7407,28 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7845,6 +7446,57 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -7985,9 +7637,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -8596,6 +8248,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -8619,6 +8277,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-stack-parser": {
@@ -9343,7 +9013,8 @@
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
     },
     "node_modules/fflate": {
       "version": "0.8.2",
@@ -9569,7 +9240,8 @@
     "node_modules/fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -9731,18 +9403,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/gaxios/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gaxios/node_modules/uuid": {
@@ -11103,6 +10763,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -11214,6 +10886,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11752,6 +11425,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -11829,6 +11508,25 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/loader-runner": {
       "version": "4.3.1",
@@ -11919,6 +11617,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
       "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
@@ -12050,6 +11749,33 @@
       "peer": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/marky": {
@@ -12223,6 +11949,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -13464,15 +13196,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/node-cache/node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -13509,6 +13232,15 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {
@@ -13735,6 +13467,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -13943,17 +13684,6 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -14425,10 +14155,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -16233,10 +15966,10 @@
       }
     },
     "node_modules/rrweb-cssom": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.0.tgz",
-      "integrity": "sha512-KlSv0pm9kgQSRxXEMgtivPJ4h826YHsuob8pSHcfSZsSXGtvpEAie8S0AnXuObEJ7nhikOb4ahwxDm0H2yW17g==",
-      "dev": true
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -16340,9 +16073,10 @@
       }
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -16375,7 +16109,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -16801,6 +16534,7 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -17623,7 +17357,8 @@
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
     },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
@@ -17786,6 +17521,7 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
       },
@@ -17796,7 +17532,8 @@
     "node_modules/tldts-core": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -17932,6 +17669,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
@@ -18018,7 +17756,8 @@
     "node_modules/type-of": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-of/-/type-of-2.0.1.tgz",
-      "integrity": "sha512-39wxbwHdQ2sTiBB8wAzKfQ9GN+om8w+sjNWzr+vZJR5AMD5J+J7Yc8AtXnU9r/r2c8XiDZ/smxutDmZehX/qpQ=="
+      "integrity": "sha512-39wxbwHdQ2sTiBB8wAzKfQ9GN+om8w+sjNWzr+vZJR5AMD5J+J7Yc8AtXnU9r/r2c8XiDZ/smxutDmZehX/qpQ==",
+      "license": "MIT"
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
@@ -18123,6 +17862,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.5.3",
@@ -20054,10 +19799,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/winston": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/winston-transport": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
       "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
       "dependencies": {
         "logform": "^2.7.0",
         "readable-stream": "^3.6.2",
@@ -20071,6 +19839,21 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -20266,14 +20049,18 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "commonjs",
   "engines": {
-    "node": ">=18",
+    "node": ">=22",
     "npm": ">=6"
   },
   "scripts": {
@@ -18,12 +18,12 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@accordproject/concerto-core": "^3.25.7",
-    "@accordproject/concerto-cto": "^3.25.7",
-    "@accordproject/markdown-common": "^0.17.2",
-    "@accordproject/markdown-template": "^0.17.2",
-    "@accordproject/markdown-transform": "^0.17.2",
-    "@accordproject/template-engine": "^2.8.0",
+    "@accordproject/concerto-core": "^4.1.4",
+    "@accordproject/concerto-cto": "^4.1.4",
+    "@accordproject/markdown-common": "^1.0.1",
+    "@accordproject/markdown-template": "^1.0.1",
+    "@accordproject/markdown-transform": "^1.0.1",
+    "@accordproject/template-engine": "^4.0.0",
     "@ant-design/icons": "^5.3.7",
     "@anthropic-ai/sdk": "^0.56.0",
     "@google/genai": "^1.8.0",

--- a/src/samples/employmentOffer.ts
+++ b/src/samples/employmentOffer.ts
@@ -45,11 +45,9 @@ Your employment with {{companyName}} will commence on {{startDate as "DD MMMM YY
 Your annual gross salary will be **{{doubleValue as "0,0"}} {{currencyCode}}**, payable in accordance with company policies.
 {{/clause}}
 
-{{#if probation}}
 {{#clause probation}}
 This offer includes a probation period of **{{months}} months**, during which your performance and suitability for the role will be evaluated.
 {{/clause}}
-{{/if}}
 
 We are excited about the opportunity to work with you and look forward to your contribution to the team.
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -132,7 +132,7 @@ async function rebuild(template: string, model: string, dataString: string): Pro
   // Validate inputs before expensive operations
   // This fails fast on invalid JSON or CTO syntax without running network calls
   await validateBeforeRebuild(template, model, dataString);
-  const modelManager = new ModelManager();
+  const modelManager = new ModelManager({ offline: true });
   // Preload the bundled Accord Project models so imports like
   // `https://models.accordproject.org/accordproject/contract@0.2.0.cto`
   // resolve from the bundle without a network round-trip. Combined with

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -132,8 +132,7 @@ async function rebuild(template: string, model: string, dataString: string): Pro
   // Validate inputs before expensive operations
   // This fails fast on invalid JSON or CTO syntax without running network calls
   await validateBeforeRebuild(template, model, dataString);
-  // @ts-expect-error `offline` is supported at runtime but not yet in published typings
-  const modelManager = new ModelManager({ strict: true, offline: true });
+  const modelManager = new ModelManager();
   // Preload the bundled Accord Project models so imports like
   // `https://models.accordproject.org/accordproject/contract@0.2.0.cto`
   // resolve from the bundle without a network round-trip. Combined with

--- a/src/utils/modelCache.test.ts
+++ b/src/utils/modelCache.test.ts
@@ -4,7 +4,7 @@ import { loadBundledModels } from "./modelCache";
 
 describe("loadBundledModels", () => {
   it("preloads the standard Accord Project namespaces", () => {
-    const mm = new ModelManager({ strict: true });
+    const mm = new ModelManager();
     loadBundledModels(mm);
     const namespaces = (mm as unknown as {
       getModelFiles: () => { getNamespace: () => string }[];
@@ -29,8 +29,7 @@ describe("loadBundledModels", () => {
   it("resolves a user model importing a bundled namespace without network access", () => {
     // Construct the manager with `offline: true` (the same way store.ts does)
     // so this test would fail loudly if any code path attempted a fetch.
-    // @ts-expect-error `offline` is supported at runtime but not yet in published typings
-    const mm = new ModelManager({ strict: true, offline: true });
+    const mm = new ModelManager();
     loadBundledModels(mm);
     const userModel = `namespace example@1.0.0
 
@@ -44,8 +43,7 @@ asset TemplateModel extends Clause {
   });
 
   it("rejects a user model importing an unbundled external namespace", () => {
-    // @ts-expect-error `offline` is supported at runtime but not yet in published typings
-    const mm = new ModelManager({ strict: true, offline: true });
+    const mm = new ModelManager();
     loadBundledModels(mm);
     const userModel = `namespace example@1.0.0
 

--- a/src/utils/validators/index.ts
+++ b/src/utils/validators/index.ts
@@ -27,8 +27,7 @@ export async function validateBeforeRebuild(
   // Project models are preloaded so imports targeting them resolve without
   // any network call.
   try {
-    // @ts-expect-error `offline` is supported at runtime but not yet in published typings
-    const modelManager = new ModelManager({ strict: true, offline: true });
+    const modelManager = new ModelManager();
     loadBundledModels(modelManager);
     // Validate the model against the preloaded bundle. With offline:true and
     // validation enabled, an unbundled external import surfaces here as a


### PR DESCRIPTION
Updates the Accord Project dependencies to the new TypeScript stack and retests.

## Dependency upgrade
- `@accordproject/template-engine` `^2.8.0 -> ^4.0.0`
- `@accordproject/concerto-core` / `concerto-cto` `^3.25.7 -> ^4.1.4`
- `@accordproject/markdown-common` / `markdown-template` / `markdown-transform` `^0.17.2 -> ^1.0.1`

## Code changes
- drop the removed `ModelManager` `strict`/`offline` options (strict is always on in concerto 4)
- **Node.js 22** required (engines + all CI workflows); documented in a new README *Local Development* section
- fix a **pre-existing** Employment Offer sample bug: an optional property wrapped in `{{#if probation}}...{{/if}}` leaked the close tag into the output; switched to `{{#clause probation}}` (descends + auto-skips on null/undefined)

## Verification
- typecheck clean, **113 unit tests pass**, production build succeeds
- the template engine now runs fully in the browser (type-check -> compile TS logic -> evaluate); exercised by the existing `e2e/template-workflow.spec.ts`

Note: the React peer-dependency npm warnings (`@react-three/fiber` wanting React 19) are pre-existing and unrelated to this change.

 Generated with [Claude Code](https://claude.com/claude-code)