### PR TITLE
fix: update CONTRIBUTING.md title to reflect correct repo name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # Accord Project Template Playground Contribution Guide
 
+
 ## ❗ Accord Project Contribution Guide ❗
 We'd love for you to contribute to our source code and to make Concerto technology even better than it is today! Please refer to the [Accord Project Contribution guidelines][apcontribute] we'd like you to follow.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 
 ## ❗ Accord Project Contribution Guide ❗
-We'd love for you to contribute to our source code and to make Concerto technology even better than it is today! Please refer to the [Accord Project Contribution guidelines][apcontribute] we'd like you to follow.
+We'd love for you to contribute to our source code and to make Template Playground even better than it is today! Please refer to the [Accord Project Contribution guidelines][apcontribute] we'd like you to follow.
 
 ## Discord
 The main channel for support with Template Playground is the [Accord Project Discord Community][apdiscord].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Accord Project Concerto Contribution Guide
+# Accord Project Template Playground Contribution Guide
 
 ## ❗ Accord Project Contribution Guide ❗
 We'd love for you to contribute to our source code and to make Concerto technology even better than it is today! Please refer to the [Accord Project Contribution guidelines][apcontribute] we'd like you to follow.


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>
- <TWO>

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE>
- <TWO>

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fork:branchname`
- [ ] Fixed incorrect title in CONTRIBUTING.md. 
The heading mentioned 'Concerto' but this 
is the template-playground repository.

### Changes
- Updated title from 'Accord Project Concerto 
Contribution Guide' to 'Accord Project Template 
Playground Contribution Guide'
