### PR TITLE
feat(us06): implement execution results UI

### DIFF
--- a/src/components/ContractRunnerPanel.tsx
+++ b/src/components/ContractRunnerPanel.tsx
@@ -41,7 +41,16 @@ const ContractRunnerPanel: React.FC = () => {
       label: "Response",
       children: (
         <div className="contract-runner-panel-editor-container">
-          <JSONEditor value={executionResponse || ""} readOnly={true} />
+          {executionResponse ? (
+            <JSONEditor value={executionResponse} readOnly={true} />
+          ) : (
+            <div
+              className="contract-runner-panel-placeholder"
+              style={{ color: textColor }}
+            >
+              No response generated yet.
+            </div>
+          )}
         </div>
       ),
     },
@@ -50,7 +59,16 @@ const ContractRunnerPanel: React.FC = () => {
       label: "State",
       children: (
         <div className="contract-runner-panel-editor-container">
-          <JSONEditor value={executionState || ""} readOnly={true} />
+          {executionState ? (
+            <JSONEditor value={executionState} readOnly={true} />
+          ) : (
+            <div
+              className="contract-runner-panel-placeholder"
+              style={{ color: textColor }}
+            >
+              Contract state not initialized.
+            </div>
+          )}
         </div>
       ),
     },
@@ -59,7 +77,16 @@ const ContractRunnerPanel: React.FC = () => {
       label: "Events",
       children: (
         <div className="contract-runner-panel-editor-container">
-          <JSONEditor value={executionEvents || ""} readOnly={true} />
+          {executionEvents ? (
+            <JSONEditor value={executionEvents} readOnly={true} />
+          ) : (
+            <div
+              className="contract-runner-panel-placeholder"
+              style={{ color: textColor }}
+            >
+              No events emitted.
+            </div>
+          )}
         </div>
       ),
     },

--- a/src/components/ContractRunnerPanel.tsx
+++ b/src/components/ContractRunnerPanel.tsx
@@ -42,7 +42,7 @@ const ContractRunnerPanel: React.FC = () => {
       children: (
         <div className="contract-runner-panel-editor-container">
           {executionResponse ? (
-            <JSONEditor value={executionResponse} readOnly={true} />
+            <JSONEditor id="response" value={executionResponse} readOnly={true} />
           ) : (
             <div
               className="contract-runner-panel-placeholder"
@@ -60,7 +60,7 @@ const ContractRunnerPanel: React.FC = () => {
       children: (
         <div className="contract-runner-panel-editor-container">
           {executionState ? (
-            <JSONEditor value={executionState} readOnly={true} />
+            <JSONEditor id="state" value={executionState} readOnly={true} />
           ) : (
             <div
               className="contract-runner-panel-placeholder"
@@ -78,7 +78,7 @@ const ContractRunnerPanel: React.FC = () => {
       children: (
         <div className="contract-runner-panel-editor-container">
           {executionEvents ? (
-            <JSONEditor value={executionEvents} readOnly={true} />
+            <JSONEditor id="events" value={executionEvents} readOnly={true} />
           ) : (
             <div
               className="contract-runner-panel-placeholder"
@@ -172,7 +172,7 @@ const ContractRunnerPanel: React.FC = () => {
               <Button
                 size="small"
                 type="default"
-                onClick={initContract}
+                onClick={() => { void initContract(); }}
                 loading={isExecuting}
                 disabled={!canInit || isExecuting}
                 className="contract-runner-panel-button"
@@ -189,7 +189,7 @@ const ContractRunnerPanel: React.FC = () => {
               <Button
                 size="small"
                 type="primary"
-                onClick={triggerContract}
+                onClick={() => { void triggerContract(); }}
                 loading={isExecuting}
                 disabled={!canTrigger || isExecuting}
                 className="contract-runner-panel-button"
@@ -202,6 +202,7 @@ const ContractRunnerPanel: React.FC = () => {
         </div>
         <div className="contract-runner-panel-editor-container">
           <JSONEditor
+            id="request"
             value={requestJson}
             onChange={(val) => setRequestJson(val || "")}
           />

--- a/src/components/ContractRunnerPanel.tsx
+++ b/src/components/ContractRunnerPanel.tsx
@@ -16,6 +16,8 @@ const ContractRunnerPanel: React.FC = () => {
     triggerContract,
     logicTs,
     compiledLogicJs,
+    executionResponse,
+    executionEvents,
   } = useAppStore((s) => ({
     backgroundColor: s.backgroundColor,
     textColor: s.textColor,
@@ -27,6 +29,8 @@ const ContractRunnerPanel: React.FC = () => {
     triggerContract: s.triggerContract,
     logicTs: s.logicTs,
     compiledLogicJs: s.compiledLogicJs,
+    executionResponse: s.executionResponse,
+    executionEvents: s.executionEvents,
   }));
 
   const [activeTab, setActiveTab] = useState("response");
@@ -36,11 +40,8 @@ const ContractRunnerPanel: React.FC = () => {
       key: "response",
       label: "Response",
       children: (
-        <div
-          className="contract-runner-panel-placeholder"
-          style={{ color: textColor }}
-        >
-          Response Output Coming Soon...
+        <div className="contract-runner-panel-editor-container">
+          <JSONEditor value={executionResponse || ""} readOnly={true} />
         </div>
       ),
     },
@@ -48,11 +49,8 @@ const ContractRunnerPanel: React.FC = () => {
       key: "state",
       label: "State",
       children: (
-        <div
-          className="contract-runner-panel-placeholder"
-          style={{ color: textColor }}
-        >
-          Contract State Coming Soon...
+        <div className="contract-runner-panel-editor-container">
+          <JSONEditor value={executionState || ""} readOnly={true} />
         </div>
       ),
     },
@@ -60,11 +58,8 @@ const ContractRunnerPanel: React.FC = () => {
       key: "events",
       label: "Events",
       children: (
-        <div
-          className="contract-runner-panel-placeholder"
-          style={{ color: textColor }}
-        >
-          Emitted Events Coming Soon...
+        <div className="contract-runner-panel-editor-container">
+          <JSONEditor value={executionEvents || ""} readOnly={true} />
         </div>
       ),
     },

--- a/src/editors/JSONEditor.tsx
+++ b/src/editors/JSONEditor.tsx
@@ -14,10 +14,12 @@ export default function JSONEditor({
   value,
   onChange,
   editorRef,
+  readOnly = false,
 }: {
   value: string;
   onChange?: (value: string | undefined) => void;
   editorRef?: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>;
+  readOnly?: boolean;
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("json");
 
@@ -34,6 +36,7 @@ export default function JSONEditor({
     automaticLayout: true,
     scrollBeyondLastLine: false,
     lineNumbers: showLineNumbers ? 'on' : 'off',
+    readOnly,
     inlineSuggest: {
       enabled: aiConfig?.enableInlineSuggestions !== false,
       mode: "prefix",
@@ -50,7 +53,7 @@ export default function JSONEditor({
     acceptSuggestionOnCommitCharacter: false,
     acceptSuggestionOnEnter: "off",
     tabCompletion: "off",
-  }), [aiConfig?.enableInlineSuggestions, showLineNumbers]);
+  }), [aiConfig?.enableInlineSuggestions, showLineNumbers, readOnly]);
 
 
   const handleEditorWillMount = (monacoInstance: typeof monaco) => {

--- a/src/editors/JSONEditor.tsx
+++ b/src/editors/JSONEditor.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useCallback, useEffect } from "react";
+import { lazy, Suspense, useMemo, useCallback, useEffect, useRef } from "react";
 import * as monaco from "monaco-editor";
 import useAppStore from "../store/store";
 import useThemeName from "../hooks/useThemeName";
@@ -15,13 +15,16 @@ export default function JSONEditor({
   onChange,
   editorRef,
   readOnly = false,
+  id = "json",
 }: {
   value: string;
   onChange?: (value: string | undefined) => void;
   editorRef?: React.MutableRefObject<monaco.editor.IStandaloneCodeEditor | null>;
   readOnly?: boolean;
+  id?: string;
 }) {
   const { handleSelection, MenuComponent } = useCodeSelection("json");
+  const internalEditorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
 
   const { aiConfig, showLineNumbers } = useAppStore((state) => ({
     aiConfig: state.aiConfig,
@@ -63,20 +66,48 @@ export default function JSONEditor({
   };
 
   const handleEditorDidMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
+    internalEditorRef.current = editor;
     if (editorRef) {
       editorRef.current = editor;
     }
-    registerEditor('json', editor);
-    editor.onDidChangeCursorSelection(() => {
-      handleSelection(editor);
-    });
+    /*
+     * Monaco reuses cached models when a path already exists in its registry.
+     * In that case, the `value` prop is ignored entirely. We explicitly call
+     * setValue() here to guarantee the editor always reflects the correct data,
+     * even when a stale model was fetched from the Monaco model cache.
+     */
+        if (value !== undefined && editor.getValue() !== value) {
+      editor.setValue(value);
+    }
+    if (!readOnly) {
+      registerEditor('json', editor);
+      editor.onDidChangeCursorSelection(() => {
+        handleSelection(editor);
+      });
+    }
   };
+
+  /*
+   * Sync the value prop to the editor imperatively. The @monaco-editor/react
+   * library only uses `value` at model-creation time when a `path` is set;
+   * if the model already exists in the Monaco registry, subsequent value
+   * changes via props are ignored. This effect ensures read-only output
+   * editors always reflect the latest store data.
+   */
+  useEffect(() => {
+    const editor = internalEditorRef.current;
+    if (editor && value !== undefined && editor.getValue() !== value) {
+      editor.setValue(value);
+    }
+  }, [value]);
 
   useEffect(() => {
     return () => {
-      unregisterEditor('json');
+      if (!readOnly) {
+        unregisterEditor('json');
+      }
     };
-  }, []);
+  }, [readOnly]);
 
   const handleChange = useCallback(
     (val: string | undefined) => {
@@ -91,6 +122,7 @@ export default function JSONEditor({
         <MonacoEditor
           options={options}
           language="json"
+          path={`${id}.json`}
           height="100%"
           value={value}
           beforeMount={handleEditorWillMount}

--- a/src/styles/components/ContractRunnerPanel.css
+++ b/src/styles/components/ContractRunnerPanel.css
@@ -90,8 +90,32 @@
   pointer-events: none;
 }
 
+.contract-runner-panel-tabs .ant-tabs-content-holder,
+.contract-runner-panel-tabs .ant-tabs-content,
+.contract-runner-panel-tabs .ant-tabs-tabpane {
+  height: 100%;
+}
+
+.contract-runner-panel-tabs .ant-tabs-tabpane:not(.ant-tabs-tabpane-hidden) {
+  display: flex;
+  flex-direction: column;
+}
+
 .contract-runner-panel-editor-container {
   flex: 1;
   position: relative;
   min-height: 0;
+}
+
+.contract-runner-panel-json-display {
+  margin: 0;
+  padding: 12px;
+  height: 100%;
+  overflow: auto;
+  font-family: 'Cascadia Code', 'Fira Code', 'Consolas', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre;
+  border: none;
+  border-radius: 0;
 }

--- a/src/tests/components/ContractRunnerPanel.test.tsx
+++ b/src/tests/components/ContractRunnerPanel.test.tsx
@@ -51,8 +51,8 @@ describe('ContractRunnerPanel', () => {
     expect(screen.getByRole('tab', { name: /response/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /state/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /events/i })).toBeInTheDocument();
-    
-    // Default tab content is now a JSON editor, no need to check for placeholder
+    // Check empty state placeholders
+    expect(screen.getByText('No response generated yet.')).toBeInTheDocument();
   });
 
   it('renders correctly in dark mode', () => {

--- a/src/tests/components/ContractRunnerPanel.test.tsx
+++ b/src/tests/components/ContractRunnerPanel.test.tsx
@@ -52,8 +52,7 @@ describe('ContractRunnerPanel', () => {
     expect(screen.getByRole('tab', { name: /state/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /events/i })).toBeInTheDocument();
     
-    // Default tab content
-    expect(screen.getByText('Response Output Coming Soon...')).toBeInTheDocument();
+    // Default tab content is now a JSON editor, no need to check for placeholder
   });
 
   it('renders correctly in dark mode', () => {


### PR DESCRIPTION
Resolves #902 

### Description
This PR implements [US-06](https://github.com/orgs/accordproject/projects/30/views/1?pane=issue&itemId=186684423&issue=accordproject%7Ctemplate-playground%7C902): Execution Results Display, fulfilling the final UI requirement for the sandboxed logic execution pipeline in Phase 1.

The `ContractRunnerPanel` now actively listens to the `executionResponse`, `executionState`, and `executionEvents` variables from the global Zustand store, which are populated by the Web Worker trigger pipeline (US-05). These variables are rendered into their respective tabs using read-only instances of the `JSONEditor`.

### Files Changed

- **src/components/ContractRunnerPanel.tsx:** Bound execution output variables to the Response, State, and Events tabs, utilizing conditional rendering for empty states.

- **src/editors/JSONEditor.tsx:** Added an optional readOnly prop to securely display output data without allowing user modification (inside the output tabs).

- **src/tests/components/ContractRunnerPanel.test.tsx:** Updated placeholder assertions to align with the new conditional UI states.

### Key Changes

- **Read-Only JSON Editors:** Modified the base Monaco `JSONEditor` configuration to support a native `readOnly` prop.

- **Dynamic Data Binding:** Hooked the bottom UI tabs directly into the store to display payload outputs immediately after a contract is triggered.

- **Empty State Placeholders:** Implemented conditional rendering to show clean placeholder messages (e.g., "No response generated yet.") when the contract has not yet been executed, successfully satisfying the acceptance criteria.