### PR TITLE
fix(ui): correct sidebar keyboard actions and resize cleanup

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { colors } from '../utils/theme';
 import { useSpring, animated } from "react-spring";
 import { useLocation, Link } from "react-router-dom";
@@ -180,7 +180,7 @@ const useBreakpoint = () => {
     xl: false,
   });
 
-  useState(() => {
+  useEffect(() => {
     const checkSize = () => {
       setScreenSize({
         sm: window.innerWidth >= 640,
@@ -193,7 +193,7 @@ const useBreakpoint = () => {
     checkSize();
     window.addEventListener('resize', checkSize);
     return () => window.removeEventListener('resize', checkSize);
-  });
+  }, []);
 
   return screenSize;
 };

--- a/src/components/PlaygroundSidebar.tsx
+++ b/src/components/PlaygroundSidebar.tsx
@@ -98,6 +98,16 @@ const PlaygroundSidebar = () => {
     setContractRunnerVisible(!isContractRunnerVisible);
   };
 
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+    onClick?: () => void,
+  ) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onClick?.();
+    }
+  };
+
   interface NavItem {
     title: string;
     icon?: React.ComponentType<{ size: number }>;
@@ -198,6 +208,7 @@ const PlaygroundSidebar = () => {
             aria-label={title}
             tabIndex={0}
             onClick={onClick}
+            onKeyDown={(event) => handleKeyDown(event, onClick)}
             className={`playground-sidebar-nav-item ${
               active ? 'playground-sidebar-nav-item-active' : 'playground-sidebar-nav-item-inactive'
             } tour-${title.toLowerCase().replace(' ', '-')}`}
@@ -223,6 +234,7 @@ const PlaygroundSidebar = () => {
             aria-label={title}
             tabIndex={0}
             onClick={onClick}
+            onKeyDown={(event) => handleKeyDown(event, onClick)}
             className={`playground-sidebar-nav-bottom-item tour-${title.toLowerCase().replace(' ', '-')}`}
           >
             <Icon size={18} />

--- a/src/tests/components/Navbar.test.tsx
+++ b/src/tests/components/Navbar.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
 import Navbar from "../../components/Navbar";
 import { MemoryRouter } from "react-router-dom";
 
@@ -12,6 +13,20 @@ const renderNavbar = () => {
 };
 
 describe("Navbar", () => {
+  it("removes its resize listener when unmounted", () => {
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+    const { unmount } = render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    );
+
+    unmount();
+
+    expect(removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+    removeEventListener.mockRestore();
+  });
+
   it("renders logo and title on small screens", () => {
     renderNavbar();
 

--- a/src/tests/components/PlaygroundSidebar.test.tsx
+++ b/src/tests/components/PlaygroundSidebar.test.tsx
@@ -1,7 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import PlaygroundSidebar from "../../components/PlaygroundSidebar";
 import { vi } from "vitest";
+
+const storeActions = vi.hoisted(() => ({
+    setEditorsVisible: vi.fn(),
+}));
 
 // Mock the store
 vi.mock("../../store/store", () => ({
@@ -10,7 +14,7 @@ vi.mock("../../store/store", () => ({
         isPreviewVisible: true,
         isProblemPanelVisible: false,
         isAIChatOpen: false,
-        setEditorsVisible: vi.fn(),
+        setEditorsVisible: storeActions.setEditorsVisible,
         setPreviewVisible: vi.fn(),
         setProblemPanelVisible: vi.fn(),
         setAIChatOpen: vi.fn(),
@@ -39,6 +43,14 @@ const renderSidebar = () => {
 };
 
 describe("PlaygroundSidebar", () => {
+    it.each(["Enter", " "])("activates sidebar items with the %s key", (key) => {
+        renderSidebar();
+
+        fireEvent.keyDown(screen.getByRole("button", { name: /Editor/i }), { key });
+
+        expect(storeActions.setEditorsVisible).toHaveBeenCalledWith(false);
+    });
+
     it("renders all top navigation items", () => {
         renderSidebar();
 


### PR DESCRIPTION
## Summary

This PR fixes two small UI and accessibility issues:

- Replaces an incorrect `useState` side effect in `Navbar` with `useEffect`, ensuring the window `resize` listener is cleaned up when the component unmounts.
- Makes sidebar navigation items accessible by keyboard: pressing `Enter` or `Space` now triggers the same action as clicking the item.

## Changes

- Added `useEffect` cleanup for the Navbar breakpoint listener.
- Added shared keyboard handling to top and bottom sidebar navigation items.
- Added regression tests for:
  - Removing the Navbar resize listener on unmount.
  - Activating sidebar actions with both `Enter` and `Space`.

## Testing

- [x] `npm run test:unit -- src/tests/components/Navbar.test.tsx src/tests/components/PlaygroundSidebar.test.tsx`
  - 2 test files passed
  - 10 tests passed
- [x] `npx tsc --noEmit`
- [x] `git diff --check`

## Notes

`npm run lint` currently fails because of pre-existing lint errors in unrelated files. This PR does not introduce additional lint errors.