### PR TITLE
fix(build): emit per-route index documents for static hosting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,43 @@
-import { defineConfig as defineViteConfig, mergeConfig } from "vite";
+import { defineConfig as defineViteConfig, mergeConfig, type Plugin } from "vite";
 import { defineConfig as defineVitestConfig, configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import nodePolyfills from "vite-plugin-node-stdlib-browser";
 import { visualizer } from "rollup-plugin-visualizer";
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { steps } from "./src/constants/learningSteps/steps";
+
+const staticRoutes = ["/learn", ...steps.map((step) => step.link)];
+
+// Gives each known route its own index document so static hosts resolve it with a 200.
+function emitStaticRouteDocuments(): Plugin {
+  let outDir = "";
+
+  return {
+    name: "emit-static-route-documents",
+    apply: "build",
+    configResolved(config) {
+      outDir = resolve(config.root, config.build.outDir);
+    },
+    closeBundle() {
+      const entry = join(outDir, "index.html");
+      if (!existsSync(entry)) return;
+
+      for (const route of staticRoutes) {
+        const routeDir = join(outDir, route);
+        mkdirSync(routeDir, { recursive: true });
+        copyFileSync(entry, join(routeDir, "index.html"));
+      }
+    },
+  };
+}
+
 // https://vitejs.dev/config/
 const viteConfig = defineViteConfig({
   plugins: [nodePolyfills(), react(), visualizer({
     emitFile: true,
     filename: "stats.html",
-  })],
+  }), emitStaticRouteDocuments()],
   resolve: {
     alias: {
       // Defensive safeguard: forces axios to use the browser-safe XHR adapter


### PR DESCRIPTION
# Closes #949

Production is deployed to S3 and CloudFront, where `public/_redirects` has no effect, so every route other than `/` was answered with the S3 error document under a 404 status. This adds a build step that writes an index document for each known route, so those routes resolve on the static host and return 200.

### Changes
- Add an `emit-static-route-documents` Vite plugin that copies the built `index.html` into `dist/<route>/index.html` after the bundle is written.
- Derive the route list from `src/constants/learningSteps/steps.ts` plus `/learn`, so it follows the learning pathway instead of duplicating it.

### Flags
- `public/_redirects` is deliberately unchanged. It is what makes the Netlify deploy previews serve routes correctly and it is validated by the `Redirect rules` check, so removing it would break previews.
- The deploy preview cannot demonstrate the production fix, because Netlify already returned 200 for every path via `_redirects`. It does change one thing on the preview: now that the route directories exist, Netlify serves them as pretty URLs and answers `/learn/module1` with a 301 to `/learn/module1/` rather than a direct 200. Confirmed on this PR's preview against the preview for #943:

  ```
  route            preview before   preview after
  /                200              200
  /learn           200              301 -> /learn/ -> 200
  /learn/module1   200              301 -> /learn/module1/ -> 200
  /nonexistent-xyz 200              200
  ```

  This is benign, a permanent redirect onto a 200, and it is the same canonicalisation the S3 website endpoint performs, so the preview is now a closer match to production than it was.
- Unknown paths still return 404 after this change, which is intended. Netlify currently returns 200 for paths like `/nonexistent-xyz`, which is a soft 404 in the other direction. This pairs with the not found page proposed in #634.
- Requests without a trailing slash resolve through a redirect that the S3 website endpoint issues to the canonical trailing slash form, for example `/learn/module1` to `/learn/module1/`. Crawlers follow this and index the target. Verified that React Router matches the trailing slash form and renders the correct module.
- No automated test is included. The change affects build output shape rather than application behaviour, and the repository has no existing pattern for testing the Vite config. Happy to add one if you would like it.
- An edge level rewrite, either a CloudFront Function or a CloudFront custom error response mapping 404 to `/index.html` with a 200 status, would be a cleaner fix and would cover future routes without a build step. That configuration lives in the AWS account rather than in this repository, so it is out of scope here.

### Verification

Build output now contains an index document per route:

```
$ find dist -name index.html
dist/index.html
dist/learn/index.html
dist/learn/intro/index.html
dist/learn/module1/index.html
dist/learn/module2/index.html
dist/learn/module3/index.html
```

Serving `dist` under S3 website endpoint semantics, before and after:

```
route             before    after
/                 200       200
/learn            404       302 -> /learn/ -> 200
/learn/intro      404       302 -> /learn/intro/ -> 200
/learn/module1    404       302 -> /learn/module1/ -> 200
/learn/module3    404       302 -> /learn/module3/ -> 200
/nonexistent-xyz  404       404
```

Each route was loaded in a browser from the built output to confirm the correct module renders and no assets 404:

```
/learn/intro    -> headings ["Learning Pathway", "Introduction"]
/learn/module1  -> headings ["Learning Pathway", "Module 1", "Create a Concerto model for your template."]
/learn/module2  -> headings ["Learning Pathway", "Module 2", "Draft a TemplateMark template."]
/learn/module3  -> headings ["Learning Pathway", "Module 3", "Generate data(JSON) for the template"]
```

`npm run build` succeeds, `npm run test:unit` passes 151 tests across 23 files, and `e2e/navigation.spec.ts` passes 4 tests.

### Screenshots or Video

Not applicable. This is an HTTP status code change with no visual difference, so the `curl` output above is the meaningful evidence.

### Related Issues
- Issue #949
- Issue #634

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
