### PR TITLE
perf(build): split vendor libraries into separate chunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,19 @@ const viteConfig = defineViteConfig({
     include: ["immer"],
     needsInterop: ['@accordproject/template-engine'],
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "template-engine": ["@accordproject/template-engine"],
+          "markdown-transform": ["@accordproject/markdown-transform"],
+          "markdown-template": ["@accordproject/markdown-template"],
+          concerto: ["@accordproject/concerto-core", "@accordproject/concerto-cto"],
+          "llm-sdks": ["openai", "@anthropic-ai/sdk", "@google/genai", "@mistralai/mistralai"],
+        },
+      },
+    },
+  },
 });
 
 


### PR DESCRIPTION
# Closes #951

The entry chunk was a single 21.45 MB file. CloudFront only auto compresses objects up to 10 MB, so that file could never be compressed in transit regardless of how the distribution is configured. Splitting the heavy vendor libraries into their own chunks brings the entry chunk and most of the rest below that ceiling, so they become compressible.

This changes only how modules are distributed across output files. The same code ships, and there is no runtime behaviour change.

### Changes
- Add `build.rollupOptions.output.manualChunks` splitting `@accordproject/template-engine`, `@accordproject/markdown-transform`, `@accordproject/markdown-template`, the Concerto packages, and the four LLM SDKs into their own chunks.

### Measured effect

Clean builds of `main` at 43fabfa and of this branch, gzip computed locally, "over the wire" counting gzip for chunks at or under 10 MB and raw for anything above it:

```
                        before      after
entry chunk             21.45 MB    1.50 MB      93% smaller
total raw JS            31.91 MB    31.80 MB
total over the wire     24.34 MB    18.24 MB     25% smaller
chunks over 10 MB       1           1
```

After the split:

```
12.73 MB raw   3.76 MB gzip   template-engine-*.js     still over the ceiling
 4.29 MB raw   1.14 MB gzip   MainContainer-*.js
 4.28 MB raw   1.29 MB gzip   markdown-transform-*.js
 4.19 MB raw   1.29 MB gzip   cicero-core-*.js
 1.99 MB raw   0.60 MB gzip   markdown-template-*.js
 1.50 MB raw   0.49 MB gzip   index-*.js
 1.09 MB raw   0.18 MB gzip   llm-sdks-*.js
```

### Flags
- This only pays off once "Compress objects automatically" is enabled on the CloudFront distribution. That setting lives in the AWS account rather than in this repository. Without it the split is roughly neutral, with it the wire cost drops by about a quarter. Issue #951 covers that side.
- `@accordproject/template-engine` bundles to a single 12.73 MB module and stays above the ceiling. It cannot be split further from here, because the package's `browser` field points at a pre bundled UMD that is one module as far as rollup is concerned.
- I tried resolving the Accord Project packages to their much smaller `lib` builds with `resolve.browserField: false`. The numbers are far better, 16.67 MB raw and 4.46 MB over the wire with nothing above the ceiling, but the app does not start: it throws `TypeError: Cannot read properties of null (reading 'readFileSync')` from the template engine chunk, because those `lib` builds target Node. I have not included that change. The detail is written up in #951 since the real fix belongs in how those packages are published.
- No `Cache-Control` header is currently set on `/assets/*`. Those filenames are content hashed so `public, max-age=31536000, immutable` would be safe. Also a distribution setting, noted in #951.
- Touches `vite.config.ts`, which #950 also touches. The two edits are in different parts of the file and should merge cleanly, but whichever lands second may want a quick rebase.

### Verification

`npm run build` succeeds. Against the built output, served locally:

- Template renders, all three editors mount, the compensation total computes.
- Switching samples triggers a live rebuild correctly.
- Full logic pipeline works end to end: Apply and Compile reaches the Compiled state, Init Contract succeeds, and Send Request returns `"Alice's count is now 1 (of 10)"`. This exercises `TemplateArchiveProcessor` and the TypeScript compiler inside the split `template-engine` chunk, which is the code path most likely to break from a chunking change.
- No console or page errors.

`npm run test:unit` passes 151 tests across 23 files. `npx playwright test` passes all 20 e2e tests.

### Screenshots or Video

Not applicable. The change has no visual effect, so the build measurements above are the meaningful evidence.

### Related Issues
- Issue #951
- Pull Request #950
- Issue #117
- Pull Request #131

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
