### PR TITLE
feat(us14): obligations visual tracker

### DIFF
--- a/src/components/ContractExecutionTabs.tsx
+++ b/src/components/ContractExecutionTabs.tsx
@@ -1,6 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 import React, { useState } from "react";
 import { Tabs } from "antd";
 import JSONEditor from "../editors/JSONEditor";
+import ObligationsList from "./ObligationsList";
 import useAppStore from "../store/store";
 import usePanelHeaderBg from "../hooks/usePanelHeaderBg";
 import "../styles/components/ContractRunnerPanel.css";
@@ -18,9 +27,17 @@ const ContractExecutionTabs: React.FC = () => {
     executionEvents: s.executionEvents,
   }));
 
-  const panelHeaderBg = usePanelHeaderBg();
-
   const [activeTab, setActiveTab] = useState("response");
+
+  const isStateEmptyObject = (() => {
+    if (!executionState) return false;
+    try {
+      const parsed = JSON.parse(executionState);
+      return typeof parsed === "object" && parsed !== null && Object.keys(parsed).length === 0;
+    } catch {
+      return false;
+    }
+  })();
 
   const tabItems = [
     {
@@ -46,8 +63,15 @@ const ContractExecutionTabs: React.FC = () => {
       label: "State",
       children: (
         <div className="contract-runner-panel-editor-container">
-          {executionState ? (
+          {executionState && !isStateEmptyObject ? (
             <JSONEditor id="state" value={executionState} readOnly={true} />
+          ) : isStateEmptyObject ? (
+            <div
+              className="contract-runner-panel-placeholder"
+              style={{ color: textColor }}
+            >
+              Stateless contract (no state variables).
+            </div>
           ) : (
             <div
               className="contract-runner-panel-placeholder"
@@ -64,33 +88,22 @@ const ContractExecutionTabs: React.FC = () => {
       label: "Events",
       children: (
         <div className="contract-runner-panel-editor-container">
-          {executionEvents ? (
-            <JSONEditor id="events" value={executionEvents} readOnly={true} />
-          ) : (
-            <div
-              className="contract-runner-panel-placeholder"
-              style={{ color: textColor }}
-            >
-              No events emitted.
-            </div>
-          )}
+          <ObligationsList eventsJson={executionEvents} />
         </div>
       ),
     },
   ];
 
+  const panelHeaderBg = usePanelHeaderBg();
+
   return (
     <div className="contract-runner-panel-bottom">
       <Tabs
+        className="contract-runner-panel-tabs"
         activeKey={activeTab}
         onChange={setActiveTab}
         items={tabItems}
-        size="small"
-        className="contract-runner-panel-tabs"
-        tabBarStyle={{
-          backgroundColor: panelHeaderBg,
-          color: textColor,
-        }}
+        style={{ "--panel-header-bg": panelHeaderBg } as React.CSSProperties}
       />
     </div>
   );

--- a/src/components/ObligationsList.tsx
+++ b/src/components/ObligationsList.tsx
@@ -1,0 +1,263 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import React, { useMemo } from "react";
+import { Card, Tag, Typography, Empty, Badge } from "antd";
+import { ClockCircleOutlined, CalendarOutlined } from "@ant-design/icons";
+import JSONEditor from "../editors/JSONEditor";
+import "../styles/components/ObligationsList.css";
+
+const { Text } = Typography;
+
+interface ObligationsListProps {
+  eventsJson: string;
+}
+
+const formatGlobalTimestamp = (dateStr: string | number) => {
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return String(dateStr);
+    return d.toISOString().replace("T", " ").substring(0, 19) + " UTC";
+  } catch (e) {
+    return String(dateStr);
+  }
+};
+
+/**
+ * Strips raw Concerto resource URI prefixes like resource:org.accordproject.party@0.2.0.Party#Dan -> Dan
+ */
+const cleanResourceUri = (val: string): string => {
+  if (typeof val !== "string") return String(val);
+  return val.replace(/resource:[^#\s]+#([a-zA-Z0-9_-]+)/g, "$1");
+};
+
+/**
+ * Capitalizes field labels (e.g. amount -> Amount, description -> Description)
+ */
+const formatLabel = (field: string): string => {
+  if (!field) return "";
+  return field.charAt(0).toUpperCase() + field.slice(1);
+};
+
+
+
+/**
+ * Helper to render formatted values (MonetaryAmount, Duration, resource URIs, or JSON fallback)
+ */
+const renderFormattedValue = (value: unknown): React.ReactNode => {
+  if (value === null || value === undefined) {
+    return <Text type="secondary">null</Text>;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const obj = value as Record<string, unknown>;
+
+    // MonetaryAmount shape: { doubleValue: number, currencyCode: string }
+    if (typeof obj.doubleValue === "number" && typeof obj.currencyCode === "string") {
+      const formattedAmount = obj.doubleValue.toLocaleString("en-US", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+      return (
+        <Text className="obligation-detail-value" strong>
+          {obj.currencyCode} {formattedAmount}
+        </Text>
+      );
+    }
+
+    // Duration shape: { amount: number, unit: string }
+    if (typeof obj.amount === "number" && typeof obj.unit === "string") {
+      return (
+        <Text className="obligation-detail-value">
+          {obj.amount} {obj.unit}
+        </Text>
+      );
+    }
+
+    // Party resource shape: { partyId: string }
+    if (typeof obj.partyId === "string") {
+      return <Text className="obligation-detail-value">{obj.partyId}</Text>;
+    }
+
+    // Fallback to formatted JSON block for complex nested objects
+    return (
+      <pre className="obligation-json-block">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  if (typeof value === "string") {
+    const cleaned = cleanResourceUri(value);
+    return <Text className="obligation-detail-value">{cleaned}</Text>;
+  }
+
+  return <Text className="obligation-detail-value">{String(value)}</Text>;
+};
+
+const ObligationsList: React.FC<ObligationsListProps> = ({ eventsJson }) => {
+  const { parsedEvents, isFallback, isEmpty } = useMemo(() => {
+    if (!eventsJson || eventsJson.trim() === "" || eventsJson === "[]") {
+      return { parsedEvents: [], isFallback: false, isEmpty: true };
+    }
+
+    try {
+      const parsed = JSON.parse(eventsJson) as unknown;
+
+      if (!Array.isArray(parsed)) {
+        return { parsedEvents: [], isFallback: true, isEmpty: false };
+      }
+
+      if (parsed.length === 0) {
+        return { parsedEvents: [], isFallback: false, isEmpty: true };
+      }
+
+      // Check if it's a standard event array (each object should have $class)
+      const isValidShape = parsed.every(
+        (item) =>
+          typeof item === "object" &&
+          item !== null &&
+          typeof (item as Record<string, unknown>).$class === "string"
+      );
+
+      if (!isValidShape) {
+        return { parsedEvents: [], isFallback: true, isEmpty: false };
+      }
+
+      return {
+        parsedEvents: parsed as Record<string, unknown>[],
+        isFallback: false,
+        isEmpty: false,
+      };
+    } catch (e) {
+      return { parsedEvents: [], isFallback: true, isEmpty: false };
+    }
+  }, [eventsJson]);
+
+  if (isFallback) {
+    return <JSONEditor id="events" value={eventsJson} readOnly={true} />;
+  }
+
+  if (isEmpty) {
+    return (
+      <div className="obligations-list-container">
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="No events emitted"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="obligations-list-container">
+      {parsedEvents.map((event, index) => {
+        const fqn = event.$class as string;
+        const shortName = fqn.split(".").pop() || fqn;
+        const timestampStr = event.$timestamp as string | number | undefined;
+        const timestamp = timestampStr !== undefined ? formatGlobalTimestamp(timestampStr) : null;
+
+        // Detect if it is an obligation type.
+        const isObligation =
+          event.deadline !== undefined ||
+          event.promisor !== undefined ||
+          event.promisee !== undefined ||
+          fqn.includes("Obligation");
+
+        // Custom fields are all keys except standard ones
+        const standardKeys = [
+          "$class",
+          "$identifier",
+          "$timestamp",
+          "deadline",
+          "promisor",
+          "promisee",
+          "contract",
+        ];
+        const customFields = Object.keys(event).filter((k) => !standardKeys.includes(k));
+
+        return (
+          <Card
+            key={(event.$identifier as string | undefined) ?? `${fqn}-${timestampStr ?? ""}-${index}`}
+            className={`obligation-card ${!isObligation ? "obligation-card-generic" : ""}`}
+            size="small"
+          >
+            <div className="obligation-header">
+              <div className="obligation-title">
+                <Tag color={isObligation ? "blue" : "green"}>{shortName}</Tag>
+                {isObligation && (
+                  <Badge
+                    status="processing"
+                    text={shortName.toLowerCase().includes("obligation") ? undefined : "Obligation"}
+                  />
+                )}
+              </div>
+              {timestamp && (
+                <Text type="secondary" className="obligation-timestamp">
+                  <ClockCircleOutlined /> {timestamp}
+                </Text>
+              )}
+            </div>
+
+            <div className="obligation-details">
+              {event.deadline !== undefined && (
+                <div className="obligation-detail-row">
+                  <Text className="obligation-detail-label">
+                    <CalendarOutlined /> Deadline :
+                  </Text>
+                  <Text className="obligation-detail-value" strong>
+                    {formatGlobalTimestamp(event.deadline as string | number)}
+                  </Text>
+                </div>
+              )}
+
+              {event.promisor !== undefined && (
+                <div className="obligation-detail-row">
+                  <Text className="obligation-detail-label">Promisor :</Text>
+                  {renderFormattedValue(event.promisor)}
+                </div>
+              )}
+
+              {event.promisee !== undefined && (
+                <div className="obligation-detail-row">
+                  <Text className="obligation-detail-label">Promisee :</Text>
+                  {renderFormattedValue(event.promisee)}
+                </div>
+              )}
+
+              {customFields.map((field) => {
+                const value = event[field];
+                const isObject = typeof value === "object" && value !== null;
+                const obj = isObject ? (value as Record<string, unknown>) : null;
+                const isMonetaryOrDuration =
+                  obj !== null &&
+                  (typeof obj.doubleValue === "number" ||
+                    typeof obj.amount === "number" ||
+                    typeof obj.partyId === "string");
+
+                return (
+                  <div
+                    key={field}
+                    className={`obligation-detail-row ${
+                      isObject && !isMonetaryOrDuration ? "obligation-detail-row-vertical" : ""
+                    }`}
+                  >
+                    <Text className="obligation-detail-label">{formatLabel(field)} :</Text>
+                    {renderFormattedValue(value)}
+                  </div>
+                );
+              })}
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ObligationsList;

--- a/src/samples/index.ts
+++ b/src/samples/index.ts
@@ -15,6 +15,7 @@ import * as paymentReceipt from './paymentReceipt';
 import * as employmentOffer from "./employmentOffer";
 import * as nda from "./nda";
 import * as counterLogic from "./counterLogic";
+import * as latePaymentPenalty from "./latePaymentPenalty";
 
 export type Sample = {
   NAME: string;
@@ -29,6 +30,7 @@ export type Sample = {
 
 export const SAMPLES: Array<Sample> = [
   playground,
+  latePaymentPenalty,
   counterLogic,   // Logic sample — listed near the top to showcase the new feature
   helloworld,
   employmentOffer,

--- a/src/samples/latePaymentPenalty.ts
+++ b/src/samples/latePaymentPenalty.ts
@@ -1,0 +1,186 @@
+/**
+ * latePaymentPenalty.ts — "Late Payment Penalty" sample with TypeScript logic
+ *
+ * Demonstrates time-based math, date handling, and calculations in contract logic.
+ * Based on the late delivery and penalty template from Accord Project.
+ */
+
+export const NAME = 'Late Payment Penalty (with Logic)';
+
+export const MODEL = `namespace org.acme.latepayment@1.0.0
+
+import org.accordproject.time@0.3.0.Duration
+
+@template
+concept TemplateModel {
+  o Boolean forceMajeure
+  o Duration penaltyDuration
+  o Double penaltyPercentage
+  o Double capPercentage
+  o Duration termination
+  o String fractionalPart
+}
+
+transaction LatePaymentRequest {
+  o Boolean forceMajeure
+  o DateTime agreedPayment
+  o Double invoiceValue
+}
+
+transaction LatePaymentResponse {
+  o Double penalty
+  o Boolean sellerMayTerminate
+}
+
+event LatePaymentEvent {
+  o Boolean penaltyCalculated
+  o Boolean contractTerminated
+}
+
+asset LatePaymentState identified by stateId {
+  o String stateId
+  o Integer count
+  o Double totalPenalty
+  o Boolean isTerminated
+}
+`;
+
+export const TEMPLATE = `Late Payment and Penalty
+----
+In case of delayed payment{{#if forceMajeure}} except for Force Majeure cases,{{/if}} the Buyer shall pay to the Seller for every {{penaltyDuration}} of delay penalty amounting to {{penaltyPercentage}}% of the total value of the Invoice whose payment has been delayed.
+
+1. Any fractional part of a {{fractionalPart}} is to be considered a full {{fractionalPart}}.
+2. The total amount of penalty shall not however, exceed {{capPercentage}}% of the total value of the Invoice involved in late payment.
+3. If the delay is more than {{termination}}, the Seller is entitled to terminate this Contract.`;
+
+export const DATA = {
+  $class: 'org.acme.latepayment@1.0.0.TemplateModel',
+  forceMajeure: true,
+  penaltyDuration: {
+    $class: 'org.accordproject.time@0.3.0.Duration',
+    amount: 2,
+    unit: 'days'
+  },
+  penaltyPercentage: 10.5,
+  capPercentage: 55,
+  termination: {
+    $class: 'org.accordproject.time@0.3.0.Duration',
+    amount: 15,
+    unit: 'days'
+  },
+  fractionalPart: 'days'
+};
+
+export const REQUEST = {
+  $class: 'org.acme.latepayment@1.0.0.LatePaymentRequest',
+  forceMajeure: false,
+  agreedPayment: '2026-07-01T00:00:00.000Z',
+  invoiceValue: 1000
+};
+
+export const LOGIC = `/*
+ * Late Payment Penalty Logic
+ * Demonstrates: Date/time handling, mathematical calculations, and cap enforcements
+ */
+
+class LatePaymentLogic extends TemplateLogic<any> {
+
+  // Initialize the contract state
+  async init(data: any) {
+    return {
+      state: {
+        $class: 'org.acme.latepayment@1.0.0.LatePaymentState',
+        stateId: 'late-payment-state',
+        $identifier: 'late-payment-state',
+        count: 0,
+        totalPenalty: 0,
+        isTerminated: false
+      },
+      events: []
+    };
+  }
+
+  // Called for each request — calculates penalty based on days overdue
+  async trigger(data: any, request: any, state: any) {
+    const currentCount = (state?.count ?? 0) as number;
+    const currentTotalPenalty = (state?.totalPenalty ?? 0) as number;
+    const isAlreadyTerminated = (state?.isTerminated ?? false) as boolean;
+
+    /*
+     * Force Majeure: if the contract excludes penalties for force majeure
+     * and the request claims force majeure, waive the penalty entirely
+     */
+    if (data.forceMajeure && request.forceMajeure) {
+      return {
+        result: {
+          $class: 'org.acme.latepayment@1.0.0.LatePaymentResponse',
+          $timestamp: new Date(),
+          penalty: 0,
+          sellerMayTerminate: false
+        },
+        events: [{
+          $class: 'org.acme.latepayment@1.0.0.LatePaymentEvent',
+          $timestamp: new Date(),
+          penaltyCalculated: false,
+          contractTerminated: false
+        }],
+        state: {
+          $class: 'org.acme.latepayment@1.0.0.LatePaymentState',
+          stateId: state.stateId,
+          $identifier: state.stateId,
+          count: currentCount + 1,
+          totalPenalty: currentTotalPenalty,
+          isTerminated: isAlreadyTerminated
+        }
+      };
+    }
+
+    // Demonstrate date/time handling
+    const agreedPaymentDate = new Date(request.agreedPayment);
+    // Use request timestamp for evaluation if available, else current date
+    const evaluationDate = request.$timestamp ? new Date(request.$timestamp) : new Date();
+
+    let daysOverdue = 0;
+    if (evaluationDate > agreedPaymentDate) {
+      const diffTime = Math.abs(evaluationDate.getTime() - agreedPaymentDate.getTime());
+      daysOverdue = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    }
+
+    // Calculate penalty periods (each period = penaltyDuration amount in days)
+    const penaltyPeriods = Math.floor(daysOverdue / data.penaltyDuration.amount);
+    let penalty = penaltyPeriods * (data.penaltyPercentage / 100) * request.invoiceValue;
+
+    // The total amount of penalty shall not exceed capPercentage
+    const maxPenalty = (data.capPercentage / 100) * request.invoiceValue;
+    if (penalty > maxPenalty) {
+      penalty = maxPenalty;
+    }
+
+    // Terminate condition
+    const sellerMayTerminate = daysOverdue > data.termination.amount;
+
+    return {
+      result: {
+        $class: 'org.acme.latepayment@1.0.0.LatePaymentResponse',
+        $timestamp: new Date(),
+        penalty: penalty,
+        sellerMayTerminate: sellerMayTerminate
+      },
+      events: [{
+        $class: 'org.acme.latepayment@1.0.0.LatePaymentEvent',
+        $timestamp: new Date(),
+        penaltyCalculated: true,
+        contractTerminated: sellerMayTerminate
+      }],
+      state: {
+        $class: 'org.acme.latepayment@1.0.0.LatePaymentState',
+        stateId: state.stateId,
+        $identifier: state.stateId,
+        count: currentCount + 1,
+        totalPenalty: currentTotalPenalty + penalty,
+        isTerminated: isAlreadyTerminated || sellerMayTerminate
+      }
+    };
+  }
+}
+`;

--- a/src/samples/latePaymentPenalty.ts
+++ b/src/samples/latePaymentPenalty.ts
@@ -10,6 +10,8 @@ export const NAME = 'Late Payment Penalty (with Logic)';
 export const MODEL = `namespace org.acme.latepayment@1.0.0
 
 import org.accordproject.time@0.3.0.Duration
+import org.accordproject.obligation@0.2.0.PaymentObligation
+import org.accordproject.money@0.3.0.MonetaryAmount
 
 @template
 concept TemplateModel {
@@ -166,12 +168,27 @@ class LatePaymentLogic extends TemplateLogic<any> {
         penalty: penalty,
         sellerMayTerminate: sellerMayTerminate
       },
-      events: [{
-        $class: 'org.acme.latepayment@1.0.0.LatePaymentEvent',
-        $timestamp: new Date(),
-        penaltyCalculated: true,
-        contractTerminated: sellerMayTerminate
-      }],
+      events: [
+        {
+          $class: 'org.accordproject.obligation@0.2.0.PaymentObligation',
+          $timestamp: new Date(),
+          amount: {
+            $class: 'org.accordproject.money@0.3.0.MonetaryAmount',
+            doubleValue: penalty,
+            currencyCode: 'USD'
+          },
+          description: 'Penalty for late payment',
+          promisor: 'resource:org.accordproject.party@0.2.0.Party#Buyer',
+          promisee: 'resource:org.accordproject.party@0.2.0.Party#Seller',
+          deadline: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString()
+        },
+        {
+          $class: 'org.acme.latepayment@1.0.0.LatePaymentEvent',
+          $timestamp: new Date(),
+          penaltyCalculated: true,
+          contractTerminated: sellerMayTerminate
+        }
+      ],
       state: {
         $class: 'org.acme.latepayment@1.0.0.LatePaymentState',
         stateId: state.stateId,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -431,6 +431,8 @@ const useAppStore = create<AppState>()(
             const state = get();
             const logicTs = sample.LOGIC ?? "";
             const hasLogic = !!sample.LOGIC && state.isLogicFeatureEnabled;
+            const defaultRequest = '{\n  "$class": "org.acme.counter@1.0.0.CounterRequest",\n  "increment": 1\n}';
+            const requestJson = sample.REQUEST ? JSON.stringify(sample.REQUEST, null, 2) : defaultRequest;
             set(() => ({
               sampleName: sample.NAME,
               agreementHtml: undefined,
@@ -441,6 +443,7 @@ const useAppStore = create<AppState>()(
               editorModelCto: sample.MODEL,
               data: JSON.stringify(sample.DATA, null, 2),
               editorAgreementData: JSON.stringify(sample.DATA, null, 2),
+              requestJson,
               // Reset logic state when switching samples
               logicTs,
               editorLogicTs: logicTs,

--- a/src/styles/components/ObligationsList.css
+++ b/src/styles/components/ObligationsList.css
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+.obligations-list-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  box-sizing: border-box;
+  overflow-y: auto !important;
+  overflow-x: hidden;
+  padding: 16px 16px 48px 16px;
+  background-color: transparent;
+}
+
+.obligations-list-container::-webkit-scrollbar {
+  width: 8px;
+}
+
+.obligations-list-container::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.obligations-list-container::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 4px;
+}
+
+.obligations-list-container::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="dark"] .obligations-list-container::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+[data-theme="dark"] .obligations-list-container::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+[data-theme="dark"] .obligations-list-container::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.45);
+}
+
+.obligations-list-container .ant-empty {
+  margin-top: 48px;
+}
+
+.obligation-card {
+  margin-bottom: 16px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  border-left: 4px solid var(--ant-color-primary, #19c6c7);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.02);
+  border-radius: 8px;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.obligation-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.04);
+}
+
+.obligation-card-generic {
+  border-left: 4px solid var(--ant-color-success, #52c41a);
+}
+
+.obligation-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  width: 100%;
+}
+
+.obligation-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.obligation-details {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.obligation-detail-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.obligation-detail-row-vertical {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.obligation-detail-label {
+  font-weight: 600;
+  min-width: auto;
+  margin-right: 4px;
+  color: var(--ant-color-text-secondary, #666666);
+  font-size: 13px;
+  text-transform: capitalize;
+}
+
+.obligation-detail-value {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  color: var(--ant-color-text, #222222);
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+.obligation-amount-pill {
+  font-size: 13px !important;
+  font-weight: 600 !important;
+  padding: 3px 12px !important;
+  border-radius: 16px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  box-shadow: 0 1px 3px rgba(82, 196, 26, 0.15);
+}
+
+.obligation-duration-pill {
+  font-size: 12.5px !important;
+  font-weight: 600 !important;
+  padding: 2px 10px !important;
+  border-radius: 12px !important;
+}
+
+/* Dark Mode Styles */
+[data-theme="dark"] .obligation-card {
+  background-color: #1e1e1e;
+  border-color: #303030;
+  border-left-color: var(--ant-color-primary, #19c6c7);
+}
+
+[data-theme="dark"] .obligation-card:hover {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  background-color: #252525;
+}
+
+[data-theme="dark"] .obligation-card-generic {
+  border-left-color: var(--ant-color-success, #49aa19);
+}
+
+[data-theme="dark"] .obligation-detail-label {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+[data-theme="dark"] .obligation-detail-value {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+[data-theme="dark"] .obligation-timestamp {
+  color: rgba(255, 255, 255, 0.45) !important;
+}
+
+[data-theme="dark"] .obligations-list-container .ant-empty-description {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.obligation-json-block {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 8px 12px;
+  background-color: rgba(0, 0, 0, 0.03);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 6px;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+  color: var(--ant-color-text, #222222);
+}
+
+[data-theme="dark"] .obligation-json-block {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.88);
+}

--- a/src/tests/components/ObligationsList.test.tsx
+++ b/src/tests/components/ObligationsList.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ObligationsList from "../../components/ObligationsList";
+
+// Mock JSONEditor so we don't have to render Monaco in unit tests
+vi.mock("../../editors/JSONEditor", () => ({
+  default: ({ value }: { value: string }) => <div data-testid="json-editor">{value}</div>,
+}));
+
+// Mock useAppStore if we ever needed it, but ObligationsList doesn't use it directly
+
+describe("ObligationsList", () => {
+  it("renders empty state when eventsJson is empty string", () => {
+    render(<ObligationsList eventsJson="" />);
+    expect(screen.getByText("No events emitted")).toBeInTheDocument();
+  });
+
+  it("renders empty state when eventsJson is '[]'", () => {
+    render(<ObligationsList eventsJson="[]" />);
+    expect(screen.getByText("No events emitted")).toBeInTheDocument();
+  });
+
+  it("falls back to JSONEditor for malformed JSON", () => {
+    render(<ObligationsList eventsJson="invalid json" />);
+    expect(screen.getByTestId("json-editor")).toHaveTextContent("invalid json");
+  });
+
+  it("falls back to JSONEditor if parsed data is not an array", () => {
+    render(<ObligationsList eventsJson='{"not": "an array"}' />);
+    expect(screen.getByTestId("json-editor")).toHaveTextContent('{"not": "an array"}');
+  });
+
+  it("falls back to JSONEditor if array contains non-objects or items without $class", () => {
+    render(<ObligationsList eventsJson='[{"missing": "class"}]' />);
+    expect(screen.getByTestId("json-editor")).toHaveTextContent('[{"missing": "class"}]');
+  });
+
+  it("renders an obligation correctly", () => {
+    const obligationJson = JSON.stringify([
+      {
+        $class: "org.accordproject.runtime@0.2.0.Obligation",
+        $timestamp: "2026-07-30T12:00:00Z",
+        deadline: "2026-08-30T12:00:00Z",
+        promisor: "Alice",
+        promisee: "Bob",
+        amount: 100
+      }
+    ]);
+
+    render(<ObligationsList eventsJson={obligationJson} />);
+
+    // Should not show empty state or fallback
+    expect(screen.queryByText("No events emitted")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("json-editor")).not.toBeInTheDocument();
+
+    // Renders tags and badges
+    expect(screen.getAllByText("Obligation").length).toBeGreaterThan(0); // Badge text and shortname
+    expect(screen.getByText(/Deadline\s*:/i)).toBeInTheDocument();
+    expect(screen.getByText("Promisor :")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Promisee :")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    
+    // Custom fields
+    expect(screen.getByText("Amount :")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
+  });
+
+  it("renders a generic event correctly", () => {
+    const genericEventJson = JSON.stringify([
+      {
+        $class: "org.acme.counter@1.0.0.CounterUpdated",
+        $timestamp: "2026-07-30T12:00:00Z",
+        previousCount: 0,
+        nextCount: 1
+      }
+    ]);
+
+    render(<ObligationsList eventsJson={genericEventJson} />);
+
+    // Renders tags and badges
+    expect(screen.getByText("CounterUpdated")).toBeInTheDocument();
+    
+    // Should NOT have the Obligation badge
+    expect(screen.queryByText("Obligation")).not.toBeInTheDocument();
+    
+    // Custom fields
+    expect(screen.getByText("PreviousCount :")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("NextCount :")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("handles object-type custom fields gracefully", () => {
+    const genericEventJson = JSON.stringify([
+      {
+        $class: "org.acme.counter@1.0.0.CustomEvent",
+        nestedObject: { key: "value" }
+      }
+    ]);
+
+    const { container } = render(<ObligationsList eventsJson={genericEventJson} />);
+    expect(screen.getByText("NestedObject :")).toBeInTheDocument();
+    const jsonBlock = container.querySelector(".obligation-json-block");
+    expect(jsonBlock).not.toBeNull();
+    expect(jsonBlock?.textContent).toContain('"key": "value"');
+  });
+});


### PR DESCRIPTION
Resolves #910

### PR Summary 
Contract execution events were previously displayed as unformatted raw JSON strings in Template Playground, making contract outcomes hard to inspect.

This PR introduces the [US-14: Obligations Visual Tracker](https://github.com/orgs/accordproject/projects/30/views/1?pane=issue&itemId=186684670&issue=accordproject%7Ctemplate-playground%7C910), rendering contract obligations, payment amounts, deadlines, and domain events as clean, structured visual cards in the Events tab.

### Key Changes

**1. ObligationsList.tsx & ObligationsList.css (New Visual Component)**

- **Obligation vs. Non-Obligation Event Cards:** Distinguishes standard payment obligations (Blue Tag badge) from generic domain events like `CounterUpdated` (Green Tag badge with capitalized key-value rows).
- **Concerto URI Sanitizer:** Recursively strips internal Concerto prefixes (`resource:...#Party#Dan $\rightarrow$ Dan`).
- **Amount Formatter:** Detects `MonetaryAmount` objects and formats them as plain text (USD 110.00).
- **Generic Event Parser:** Strips internal metadata (`$class`, `$identifier`, `$timestamp`) and capitalizes custom keys (`PreviousCount: 2`, `NextCount: 3`).
- **Global UTC Timestamps:** Formats all event timestamps in standardized UTC format (YYYY-MM-DD HH:mm:ss UTC) for consistent, time-zone-independent contract execution tracking.
- **Theme-Aware Cards:** Complete Ant Design Card, Tag, and Badge integration supporting both light and dark modes.

**2. ContractExecutionTabs.tsx (UI Integration)**

- Replaced raw JSON text area in the Events tab with `<ObligationsList eventsJson={executionEvents} />`.
- Added detection for empty contract state (`{ state: {} }`) to display "_Stateless contract (no state variables)_." in the State tab.

**3. ObligationsList.test.tsx (Automated Test Suite)**

- 8 Vitest unit tests verifying single obligations, event lists, URI namespace stripping, amount formatting, generic events, empty states, and fallback behavior.

### Testing & Verification
- Automated Unit Tests: All 8 Vitest unit tests passed (8 passed (8)):
`npx vitest run src/tests/components/ObligationsList.test.tsx`
- Manual Verification: Verified rendering across `latedeliveryandpenalty`, `counter`,  and `helloworld` templates in both light and dark themes.

### Flags
- **Companion PR in cicero-template-library:** A companion PR in [accordproject/cicero-template-library](https://github.com/accordproject/cicero-template-library/pull/new/fix/include-logic-ts-in-playground-url) which will fix the generation of "Open in Template Playground" share URLs for sample templates (including `latedeliveryandpenalty`). It embeds `logicTs` and `requestJson` directly in the share payload so logic compiles automatically upon opening in the Playground.
- **Dark Mode UI & Runner Layout Polish PR:** Some UI polish and dark mode contrast fixes (for Settings Modal text, runner panel 50/50 flex split, and inactive tab contrast) will be submitted in a separate follow-up PR. 
