### PR TITLE
fix(build): split vendor libraries into manual chunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,7 @@ const viteConfig = defineViteConfig({
           'concerto': ['@accordproject/concerto-core', '@accordproject/concerto-cto'],
           'anthropic': ['@anthropic-ai/sdk'],
           'google-genai': ['@google/genai'],
-          'mistral': ['@mistralai/mistralai'],
+          'mistral': ['@mistralai/mistralai', '@mistralai/mistralai/models/components/chatcompletionstreamrequest'],
           'openai': ['openai'],
         },
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,22 @@ const viteConfig = defineViteConfig({
     include: ["immer"],
     needsInterop: ['@accordproject/template-engine'],
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'template-engine': ['@accordproject/template-engine'],
+          'markdown-transform': ['@accordproject/markdown-transform'],
+          'markdown-template': ['@accordproject/markdown-template'],
+          'concerto': ['@accordproject/concerto-core', '@accordproject/concerto-cto'],
+          'anthropic': ['@anthropic-ai/sdk'],
+          'google-genai': ['@google/genai'],
+          'mistral': ['@mistralai/mistralai'],
+          'openai': ['openai'],
+        },
+      },
+    },
+  },
 });
 
 


### PR DESCRIPTION
### Description
Fixes #951 

This PR addresses the CloudFront 10 MB compression ceiling issue by splitting the large vendor libraries into their own manual chunks during the production build. 

Previously, the production entry chunk was 22.5 MB, which prevented CloudFront from applying gzip/brotli compression. By configuring `build.rollupOptions.output.manualChunks` in `vite.config.ts`, these dependencies have been split up. 

**Split Chunks Include:**
- `@accordproject/template-engine`
- `@accordproject/markdown-transform`
- `@accordproject/markdown-template`
- Concerto packages (`@accordproject/concerto-core` and `@accordproject/concerto-cto`)
- LLM SDKs (`@anthropic-ai/sdk`, `@google/genai`, `@mistralai/mistralai`, `openai`)

### Results
- The main entry chunk (`index.js`) is drastically reduced (from ~22.5 MB down to ~1.5 MB).
- While `@accordproject/template-engine` remains above the 10 MB ceiling due to its own internal UMD bundling, the vast majority of the application's dependencies are now fully compressed over the wire.
- This results in much faster initial loading times, especially on mobile and low-bandwidth connections.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
- [x] Ran `npm run build` and verified the output chunk sizes in `dist/assets/`.
- [x] Passed all Unit Tests (`npm run test:unit`)
- [x] Passed all E2E Tests (`npm run test:e2e`)