### PR TITLE
fix(navbar): move useBreakpoint resize listener into useEffect

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { colors } from '../utils/theme';
 import { useSpring, animated } from "react-spring";
 import { useLocation, Link } from "react-router-dom";
@@ -180,7 +180,7 @@ const useBreakpoint = () => {
     xl: false,
   });
 
-  useState(() => {
+  useEffect(() => {
     const checkSize = () => {
       setScreenSize({
         sm: window.innerWidth >= 640,
@@ -193,7 +193,7 @@ const useBreakpoint = () => {
     checkSize();
     window.addEventListener('resize', checkSize);
     return () => window.removeEventListener('resize', checkSize);
-  });
+  }, []);
 
   return screenSize;
 };

--- a/src/tests/components/Navbar.test.tsx
+++ b/src/tests/components/Navbar.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Navbar from "../../components/Navbar";
 import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
 
 const renderNavbar = () => {
-  render(
+  return render(
     <MemoryRouter>
       <Navbar />
     </MemoryRouter>
@@ -39,5 +40,19 @@ describe("Navbar", () => {
     expect(homeMenuItem).not.toHaveStyle({
       backgroundColor: "rgba(255, 255, 255, 0.1)",
     });
+  });
+
+  it("removes the resize listener on unmount", () => {
+    const removeEventListener = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderNavbar();
+
+    unmount();
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+
+    removeEventListener.mockRestore();
   });
 });


### PR DESCRIPTION
# Closes #850

The `useBreakpoint` hook in `Navbar.tsx` set up its `resize` listener inside a `useState` initializer. React ignores the value that initializer returns, so the cleanup never ran and a listener was left behind every time the Navbar unmounted. Moving the same code into `useEffect` with an empty dependency array lets the cleanup remove the listener.

### Changes
- Replace `useState` with `useEffect(..., [])` in the `useBreakpoint` hook in `src/components/Navbar.tsx`
- Add a Navbar test that the resize listener is removed on unmount

### Flags
- The first size check now runs after mount instead of during the first render, so the hook returns all `false` for one render. The existing Navbar tests still pass.
- I checked the new test by putting the old `useState` version back: it fails there and passes with the fix.

### Related Issues
- Issue #850

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`