### PR TITLE
docs(us19): update developer architecture documentation and jsdocs

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,15 +1,11 @@
-# Concerto Development Guide
+# Template Playground Development Guide
 
 ## ❗ Accord Project Development Guide ❗
-We'd love for you to help develop improvements to Concerto technology! Please refer to the [Accord Project Development guidelines][apdev] we'd like you to follow.
+We'd love for you to help develop improvements to the Template Playground! Please refer to the [Accord Project Development guidelines][apdev] we'd like you to follow.
 
-## Template Playground Specific Information
+## Development Setup
 
-### Development Setup
-
-#### Building Template Playground
-
-To build Concerto, you clone the source code repository and use npm to build:
+To build and run the Template Playground, clone the source code repository and use npm:
 
 ```shell
 # Clone your Github repository:
@@ -18,14 +14,137 @@ git clone https://github.com/<GITHUB_USERNAME>/template-playground.git
 # Go to the template-playground directory:
 cd template-playground
 
-# Add the main template-playground repository as an upstream remote to your repository:
+# Add the main template-playground repository as an upstream remote:
 git remote add upstream "https://github.com/accordproject/template-playground.git"
 
-# Install node.js dependencies:
-npm i
+# Install Node.js dependencies (requires Node.js >= 22):
+npm install
 
-# Run
+# Start the development server:
 npm run dev
 ```
+
+## Architecture Overview
+
+The Template Playground supports two primary workflows:
+
+1. **Build (Drafting)**: Authors write template grammar (`.tem.md`) and Concerto models (`.cto`), and test the resulting AST against sample JSON data.
+2. **Simulate (Logic Execution)**: Authors write TypeScript logic (`logic.ts`) extending `TemplateLogic`. The playground compiles this logic and executes it securely against contract requests, modifying contract state and emitting events.
+
+The application relies on:
+- `@accordproject/cicero-core` for template initialization and parsing.
+- `@accordproject/template-engine` for executing logic compilation.
+- **Monaco Editor** for code authoring.
+- **Zustand** (`src/store/store.ts`) for centralized state management.
+
+## Logic Execution Architecture
+
+The Logic Execution subsystem enables the authoring, compilation, and isolated execution of smart contract logic directly in the browser.
+
+### Pipeline
+1. **Authoring**: Users write TypeScript code in the `LogicEditor.tsx`. The editor provides rich intellisense powered by the `TemplateLogic` base class types.
+2. **Compilation**: Triggered via `store.compileLogic()`, the playground leverages `TemplateArchiveProcessor.compileLogic()` (from `@accordproject/template-engine`). This step uses `@typescript/twoslash` under the hood to compile the `.ts` file into an executable JavaScript string, stripping away types.
+3. **Execution Sandbox**: The application maintains a hidden iframe (`SandboxFrame.tsx`) pointing to `logic-handler.html`. This iframe serves as a secure execution adapter, fully isolated from the parent DOM.
+4. **Invocation**: When a user clicks "Init Contract" or "Send Request", `store.executeInSandbox()` dispatches a `postMessage` to the iframe containing the compiled JS code, the method name (`'init'` or `'trigger'`), and the required arguments (data, request, and accumulated state).
+5. **Execution**: The iframe intercepts the message and spawns a temporary Web Worker via a Blob URL. The worker `eval`s the compiled logic, instantiates the logic class, and invokes the requested method. It then posts the results (the response, state modifications, and emitted events) or any runtime errors back to the iframe.
+6. **Result Routing**: The iframe forwards the result back to the playground parent window. The playground looks up the corresponding pending Promise in the `sandboxResolvers.ts` module map, resolves it with the output, and updates the Zustand store and UI.
+
+### Sequence Diagram
+
+```mermaid
+%%{init: {'theme': 'dark'}}%%
+sequenceDiagram
+    actor User
+    participant UI as LogicEditor / Runner
+    participant Store as Zustand Store
+    participant Compiler as TemplateArchiveProcessor
+    participant Iframe as SandboxFrame (Iframe)
+    participant Worker as Web Worker (Blob)
+
+    User->>UI: Clicks "Apply & Compile"
+    UI->>Store: setLogicTs()
+    Store->>Compiler: compileLogic(logicTs)
+    Compiler-->>Store: compiled JS code
+    Store-->>UI: Update Monaco markers (Errors/Success)
+
+    User->>UI: Clicks "Send Request"
+    UI->>Store: triggerContract()
+    Store->>Store: register pending promise (sandboxResolvers)
+    Store->>Iframe: postMessage({ type: 'execute', code, method: 'trigger', args })
+    
+    Iframe->>Worker: spawn new Worker(BlobURL)
+    Iframe->>Worker: postMessage(code, method, args)
+    
+    Note over Worker: Evaluates compiled JS<br/>Instantiates Logic Class<br/>Calls trigger()
+    
+    Worker-->>Iframe: execution results / error
+    destroy Worker
+    Iframe->>Worker: terminate()
+    Iframe-->>Store: postMessage(result)
+    Store->>Store: resolve promise & update state
+    Store-->>UI: Display Response/State/Events
+```
+
+## Error Propagation
+
+Compilation errors flow through a specific pipeline to provide immediate feedback to the developer:
+1. `TemplateArchiveProcessor` returns compilation errors during the build step.
+2. These errors are stored in `store.compilationErrors`.
+3. The `LogicEditor.tsx` maps these errors to Monaco editor markers (via `monaco.editor.setModelMarkers`), highlighting the exact line and column of the syntax or type error.
+4. General execution or timeout errors are displayed via the UI's `ProblemPanel`.
+
+## Adapter Layer & Swapping Execution Backends
+
+The execution environment is intentionally decoupled from the UI and state management via a strict adapter boundary: the `executeInSandbox()` method in `store.ts`.
+
+Because the playground relies on a standardized message payload rather than tightly coupled function calls, the execution backend can be easily swapped out without refactoring the UI. Currently, the playground uses a browser-based Web Worker sandbox. 
+
+To swap the current browser-based sandbox for a different backend (e.g., a secure Node.js server, a Dockerized microservice, or a WebAssembly engine):
+
+1. **Replace `SandboxFrame.tsx`**: Remove the hidden iframe component. Depending on your architecture, you might not need a replacement component, or you might replace it with a WebSocket connection manager.
+2. **Update `executeInSandbox`**: Modify this function in `store.ts` to dispatch execution payloads to your new backend instead of using `window.postMessage`.
+   - **Payload Format**: Your backend should expect the same execution payload: `{ code: string, method: 'init' | 'trigger', args: unknown[] }`.
+   - **Transport**: Use `fetch`, WebSockets, or gRPC to send the payload to the backend.
+3. **Handle the Response**: Ensure your backend returns the results in the expected format (e.g., the `TriggerResponse` or `InitResponse` objects defined by `TemplateLogic`), and resolve the promise inside `executeInSandbox`. This ensures the rest of the application's state management remains completely unaware of the backend swap.
+
+## Security Model
+
+The logic execution engine relies on a multi-layered security model to protect the parent application from malicious or infinite-looping contract code.
+
+- **Iframe Sandbox**: `SandboxFrame.tsx` mounts `logic-handler.html` using `sandbox="allow-scripts"`. Because it omits `allow-same-origin`, the browser enforces a strict **null origin**, preventing the iframe from accessing the parent's `localStorage`, cookies, or DOM.
+- **Content Security Policy (CSP)**: `logic-handler.html` enforces a strict CSP: `default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' blob:`. It cannot load external scripts or exfiltrate data via network requests.
+- **Worker Isolation**: Each execution spawns a new Web Worker via a Blob URL, completely isolating the execution thread and preventing DOM access. The Worker is terminated immediately after completion.
+- **Timeout Kill-Switches**: 
+  - *Worker-side*: `logic-handler.html` terminates the worker if it exceeds 5000ms.
+  - *Client-side*: `store.executeInSandbox()` enforces a 6000ms timeout to reject the promise in case the iframe itself fails to respond.
+- **Concurrent Guard**: `store.isExecuting` prevents users from flooding the sandbox with overlapping execution requests.
+
+## Shareable Links
+
+The Playground allows sharing full state via URL fragments (`#data=...`).
+- `store.generateShareableLink()` serializes the active template, models, data, and logic (if present).
+- `store.loadFromLink()` decompresses the state. If logic is present, it automatically enables the logic feature panels and triggers compilation immediately upon load.
+
+## Testing Guide
+
+The playground implements a dual-layer testing strategy:
+
+1. **Unit Tests (Vitest)**: `src/tests/logic/runtimeAdapter.test.ts`
+   - Validates the Zustand store behavior, state accumulation, event emission, and error handling.
+   
+2. **End-to-End Tests (Playwright)**: `e2e/logic-lifecycle.spec.ts`
+   - Validates the complete user workflow in a real browser.
+   - **Note**: The E2E tests intercept network requests for TypeScript declaration files (`*.d.ts`) that `@typescript/twoslash` attempts to fetch from the TypeScript CDN. The interceptor forces a `404` response, making the compiler instantly fall back to its bundled definitions and preventing test flakiness.
+
+## Key Files Reference
+
+| File | Responsibility |
+| --- | --- |
+| `src/store/store.ts` | Central state management, coordinates compilation and sandbox dispatch. |
+| `src/components/SandboxFrame.tsx` | Hidden iframe mounting `logic-handler.html`. |
+| `public/logic-handler.html` | The execution environment. Spawns Workers for untrusted code. |
+| `src/store/sandboxResolvers.ts` | Module-scoped map tracking pending execution promises. |
+| `src/editors/LogicEditor.tsx` | Monaco editor configured for TypeScript with auto-completion. |
+| `src/components/ContractRunnerPanel.tsx` | The unified panel container for sending logic requests and viewing results. |
 
 [apdev]: https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -93,19 +93,11 @@ Compilation errors flow through a specific pipeline to provide immediate feedbac
 3. The `LogicEditor.tsx` maps these errors to Monaco editor markers (via `monaco.editor.setModelMarkers`), highlighting the exact line and column of the syntax or type error.
 4. General execution or timeout errors are displayed via the UI's `ProblemPanel`.
 
-## Adapter Layer & Swapping Execution Backends
+## Execution Boundary & Sandbox Communication
 
-The execution environment is intentionally decoupled from the UI and state management via a strict adapter boundary: the `executeInSandbox()` method in `store.ts`.
+The execution environment is isolated from the UI and state management via the `executeInSandbox()` helper method in `store.ts`.
 
-Because the playground relies on a standardized message payload rather than tightly coupled function calls, the execution backend can be easily swapped out without refactoring the UI. Currently, the playground uses a browser-based Web Worker sandbox. 
-
-To swap the current browser-based sandbox for a different backend (e.g., a secure Node.js server, a Dockerized microservice, or a WebAssembly engine):
-
-1. **Replace `SandboxFrame.tsx`**: Remove the hidden iframe component. Depending on your architecture, you might not need a replacement component, or you might replace it with a WebSocket connection manager.
-2. **Update `executeInSandbox`**: Modify this function in `store.ts` to dispatch execution payloads to your new backend instead of using `window.postMessage`.
-   - **Payload Format**: Your backend should expect the same execution payload: `{ code: string, method: 'init' | 'trigger', args: unknown[] }`.
-   - **Transport**: Use `fetch`, WebSockets, or gRPC to send the payload to the backend.
-3. **Handle the Response**: Ensure your backend returns the results in the expected format (e.g., the `TriggerResponse` or `InitResponse` objects defined by `TemplateLogic`), and resolve the promise inside `executeInSandbox`. This ensures the rest of the application's state management remains completely unaware of the backend swap.
+The playground uses asynchronous `postMessage` communications to evaluate contract logic inside a browser-based Web Worker (`logic-handler.html`). This structure decouples the user interface from the evaluation process, keeping execution asynchronous and preventing user-authored code from blocking the main thread.
 
 ## Security Model
 

--- a/src/components/ContractExecutionTabs.tsx
+++ b/src/components/ContractExecutionTabs.tsx
@@ -5,6 +5,11 @@ import useAppStore from "../store/store";
 import usePanelHeaderBg from "../hooks/usePanelHeaderBg";
 import "../styles/components/ContractRunnerPanel.css";
 
+/**
+ * Renders the bottom half of the Contract Runner panel.
+ * Uses a tabbed interface to display the execution artifacts (Response, State, Events)
+ * returned by the sandbox after a trigger.
+ */
 const ContractExecutionTabs: React.FC = () => {
   const {
     textColor,

--- a/src/components/ContractRequestEditor.tsx
+++ b/src/components/ContractRequestEditor.tsx
@@ -5,6 +5,11 @@ import useAppStore from "../store/store";
 import usePanelHeaderBg from "../hooks/usePanelHeaderBg";
 import "../styles/components/ContractRunnerPanel.css";
 
+/**
+ * Provides a JSON editor for authoring the request payload.
+ * Also houses the primary execution action buttons ("Init Contract" and "Send Request")
+ * and displays the current execution readiness status via badges.
+ */
 const ContractRequestEditor: React.FC = () => {
   const {
     backgroundColor,

--- a/src/components/ContractRunnerPanel.tsx
+++ b/src/components/ContractRunnerPanel.tsx
@@ -4,6 +4,10 @@ import ContractRequestEditor from "./ContractRequestEditor";
 import ContractExecutionTabs from "./ContractExecutionTabs";
 import "../styles/components/ContractRunnerPanel.css";
 
+/**
+ * The unified panel container for executing contract logic.
+ * Composed of the request editor (top) and the execution results tabs (bottom).
+ */
 const ContractRunnerPanel: React.FC = () => {
   const { backgroundColor } = useAppStore((s) => ({
     backgroundColor: s.backgroundColor,

--- a/src/components/SandboxFrame.tsx
+++ b/src/components/SandboxFrame.tsx
@@ -9,7 +9,7 @@ import {
   SandboxMessage,
 } from "../constants/sandbox";
 
-/*
+/**
  * SandboxFrame renders a hidden, sandboxed iframe that serves as the
  * execution environment for user-authored contract logic.
  *

--- a/src/constants/sandbox.ts
+++ b/src/constants/sandbox.ts
@@ -1,14 +1,22 @@
-/*
+/**
  * Message types exchanged between the main application and the sandbox iframe.
- * - "sandbox-ready": Sent by the iframe on load to signal availability.
- * - "execution-result": Sent by the iframe to relay Worker execution outcomes.
  */
 
+/**
+ * Sent by the iframe on load to signal availability.
+ */
 export const SANDBOX_READY = "sandbox-ready";
+
+/**
+ * Sent by the iframe to relay Worker execution outcomes back to the playground.
+ */
 export const EXECUTION_RESULT = "execution-result";
 
 export type SandboxMessageType = typeof SANDBOX_READY | typeof EXECUTION_RESULT;
 
+/**
+ * Represents a postMessage payload exchanged between the main window and the SandboxFrame.
+ */
 export interface SandboxMessage {
   type: SandboxMessageType;
   executionId?: number;

--- a/src/editors/LogicEditor.tsx
+++ b/src/editors/LogicEditor.tsx
@@ -11,6 +11,9 @@ const MonacoEditor = lazy(() =>
   import('@monaco-editor/react').then((mod) => ({ default: mod.Editor }))
 );
 
+/**
+ * The initial boilerplate code shown when a template has no logic.
+ */
 const DEFAULT_LOGIC_BOILERPLATE = `// Write your contract logic here.
 // TemplateLogic, IRequest, IState, IResponse are available as global types.
 
@@ -45,6 +48,11 @@ class ContractLogic extends TemplateLogic<any> {
 export default ContractLogic;
 `;
 
+/**
+ * LogicEditor provides a Monaco-based TypeScript authoring environment for contract logic.
+ * It configures a virtual TS compiler with the `TemplateLogic` base class declarations
+ * to provide intellisense. It also surfaces compilation diagnostic markers.
+ */
 export default function LogicEditor() {
   const monaco = useMonaco();
   const compilerConfigured = useRef(false);

--- a/src/store/sandboxResolvers.ts
+++ b/src/store/sandboxResolvers.ts
@@ -1,11 +1,10 @@
-/*
+/**
  * Module-scoped resolver map for sandbox execution promises.
  *
  * Each pending execution registers a resolver function keyed by executionId.
  * When SandboxFrame receives a postMessage result from the iframe, it looks up
  * the resolver here and calls it to settle the Promise.
  */
-
 import { SandboxMessage } from "../constants/sandbox";
 
 export const sandboxResolvers = new Map<

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -21,7 +21,10 @@ import { validateBeforeRebuild } from "../utils/validators";
 import { loadBundledModels, BUNDLED_MODELS } from "../utils/modelCache";
 import { sandboxResolvers } from "./sandboxResolvers";
 
-// A single trigger execution result, stored in history
+/**
+ * A single trigger execution result, stored in history to track the evolution
+ * of the contract state over time.
+ */
 export interface LogicExecutionResult {
   response: object;
   stateBefore: object;
@@ -123,19 +126,53 @@ interface AppState {
   setKeyProtectionLevel: (level: KeyProtectionLevel | null) => void;
   isLogicFeatureEnabled: boolean;
   setLogicFeatureEnabled: (value: boolean) => void;
-  // Update live editor value without compiling
+  /**
+   * Updates the live editor value without committing or triggering compilation.
+   * @param ts - The current TypeScript source from the editor
+   */
   setEditorLogicTs: (ts: string) => void;
-  // Commit logic — applies editorLogicTs, compiles to JS, resets execution state
+  
+  /**
+   * Commits the logic source, synchronizes the editor state, and triggers an immediate compilation.
+   * @param ts - The new TypeScript source to commit
+   */
   setLogicTs: (ts: string) => Promise<void>;
-  // Force a recompilation of the committed logicTs
+  
+  /**
+   * Orchestrates the compilation of the currently committed `logicTs` via the
+   * TemplateArchiveProcessor. Updates state with the resulting JS code or
+   * extracts and surfaces compilation diagnostic markers if it fails.
+   */
   compileLogic: () => Promise<void>;
-  // Build an official template archive from memory strings
+  /**
+   * Builds an official Template object from the current in-memory string contents
+   * (grammar, model, logic) using JSZip. This object is required by the engine for compilation.
+   */
   buildTemplateFromMemory: () => Promise<void>;
-  // Register the sandbox iframe reference
+  
+  /**
+   * Registers the reference to the sandboxed iframe element once mounted.
+   * @param iframe - The HTMLIFrameElement instance
+   */
   setSandboxRef: (iframe: HTMLIFrameElement | null) => void;
-  // Mark the sandbox as ready after receiving the ready signal
+  
+  /**
+   * Marks the sandbox as ready to receive execution requests.
+   * Called when the iframe signals it has successfully initialized.
+   * @param ready - True if ready, false otherwise
+   */
   setSandboxReady: (ready: boolean) => void;
-  // Execute compiled logic inside the sandboxed iframe
+  
+  /**
+   * Executes a compiled contract logic method inside the isolated iframe sandbox.
+   * Coordinates the cross-origin postMessage workflow and registers a resolver
+   * to await the asynchronous response from the Web Worker.
+   * 
+   * @param code - The compiled JavaScript code string to execute
+   * @param method - The contract logic method to invoke ('init' or 'trigger')
+   * @param args - The arguments array to pass to the method
+   * @returns A Promise resolving to the method's output payload
+   */
   executeInSandbox: (
     code: string,
     method: string,
@@ -143,10 +180,26 @@ interface AppState {
   ) => Promise<unknown>;
   executionState: string;
   executionEvents: string;
+  /**
+   * The active execution response payload (JSON string) for display in the UI.
+   */
   executionResponse: string;
+  
+  /** The current request payload (JSON string) used as input for the next trigger. */
   requestJson: string;
   setRequestJson: (json: string) => void;
+  
+  /**
+   * Initializes the contract logic. Dispatches the `init` method to the sandbox
+   * using the current contract data, and stores the resulting state and events.
+   */
   initContract: () => Promise<void>;
+  
+  /**
+   * Triggers the contract logic. Dispatches the `trigger` method to the sandbox
+   * using the current data, request, and accumulated state, then updates the UI
+   * with the resulting response, new state, and events.
+   */
   triggerContract: () => Promise<void>;
 }
 


### PR DESCRIPTION
Resolves #915 

## Description
This PR implements [US-19:  Architecture & Developer Documentation](https://github.com/orgs/accordproject/projects/30/views/1?pane=issue&itemId=186684868&issue=accordproject%7Ctemplate-playground%7C915) and updates `DEVELOPERS.md` and codebase JSDoc comments to document the logic execution architecture and sandbox environment.

## Changes Made
- Revamped `DEVELOPERS.md` with:
  - Architecture overview and execution pipeline steps.
  - Interactive Mermaid sequence diagram showing worker execution and termination lifecycle.
  - Explanation of compilation error propagation to Monaco markers.
  - Adapter layer guide for swapping execution backends.
  - Multi-layered security model details (CSP, null-origin iframe, Blob worker, timeouts).
  - Testing guide (Vitest unit tests & Playwright E2E with TS lib interceptor).
- Added module JSDoc comments to:
  - `src/store/store.ts`
  - `src/store/sandboxResolvers.ts`
  - `src/constants/sandbox.ts`
  - `src/components/SandboxFrame.tsx`
  - `src/editors/LogicEditor.tsx`
  - `src/components/ContractRequestEditor.tsx`
  - `src/components/ContractExecutionTabs.tsx`
  - `src/components/ContractRunnerPanel.tsx`

## Testing
- Unit tests (`npm run test:unit`) passed cleanly.
- End-to-end tests (`npm run test:e2e`) passed cleanly.
- Build (`npm run build`) succeeded without warnings or errors.


