### PR TITLE
fix(ui): resolve text visibility issues in settings modal for dark mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, lazy, Suspense } from "react";
-import { App as AntdApp, Layout, Spin } from "antd";
+import { App as AntdApp, Layout, Spin, ConfigProvider, theme } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 import { Routes, Route, useSearchParams, useNavigate } from "react-router-dom";
 import Navbar from "./components/Navbar";
@@ -95,58 +95,69 @@ const App = () => {
     document.documentElement.setAttribute("data-theme", theme);
   }, [backgroundColor]);
 
+  const isDarkMode = backgroundColor === "#121212";
+
   return (
-    <AntdApp>
-      <Layout style={{ height: "100vh" }}>
-        <Navbar />
-        <Layout
-          className="app-layout"
-          style={{
-            backgroundColor,
-            height: "calc(100vh - 64px)",
-            marginTop: "64px",
-            overflow: "hidden",
-          }}
-        >
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <>
-                  <PlaygroundSidebar />
-                  <Content style={{ marginLeft: "64px" }}>
-                    {loading ? (
-                      <div className="app-content-loading">
-                        <Spinner />
-                      </div>
-                    ) : (
-                      <div className="app-main-content">
-                        <Suspense fallback={<div className="app-content-loading"><Spinner /></div>}>
-                          <MainContainer />
-                        </Suspense>
-                      </div>
-                    )}
-                  </Content>
-                </>
-              }
-            />
-            <Route
-              path="/learn"
-              element={
-                <Suspense fallback={<div className="app-content-loading"><Spinner /></div>}>
-                  <LearnNow />
-                </Suspense>
-              }
-            >
-              <Route path="intro" element={<LearnContent file="intro.md" />} />
-              <Route path="module1" element={<LearnContent file="module1.md" />} />
-              <Route path="module2" element={<LearnContent file="module2.md" />} />
-              <Route path="module3" element={<LearnContent file="module3.md" />} />
-            </Route>
-          </Routes>
+    <ConfigProvider
+      theme={{
+        algorithm: isDarkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
+        token: {
+          colorPrimary: colors.primary,
+        },
+      }}
+    >
+      <AntdApp>
+        <Layout style={{ height: "100vh" }}>
+          <Navbar />
+          <Layout
+            className="app-layout"
+            style={{
+              backgroundColor,
+              height: "calc(100vh - 64px)",
+              marginTop: "64px",
+              overflow: "hidden",
+            }}
+          >
+            <Routes>
+              <Route
+                path="/"
+                element={
+                  <>
+                    <PlaygroundSidebar />
+                    <Content style={{ marginLeft: "64px" }}>
+                      {loading ? (
+                        <div className="app-content-loading">
+                          <Spinner />
+                        </div>
+                      ) : (
+                        <div className="app-main-content">
+                          <Suspense fallback={<div className="app-content-loading"><Spinner /></div>}>
+                            <MainContainer />
+                          </Suspense>
+                        </div>
+                      )}
+                    </Content>
+                  </>
+                }
+              />
+              <Route
+                path="/learn"
+                element={
+                  <Suspense fallback={<div className="app-content-loading"><Spinner /></div>}>
+                    <LearnNow />
+                  </Suspense>
+                }
+              >
+                <Route path="intro" element={<LearnContent file="intro.md" />} />
+                <Route path="module1" element={<LearnContent file="module1.md" />} />
+                <Route path="module2" element={<LearnContent file="module2.md" />} />
+                <Route path="module3" element={<LearnContent file="module3.md" />} />
+              </Route>
+            </Routes>
+          </Layout>
         </Layout>
-      </Layout>
-    </AntdApp>
+      </AntdApp>
+    </ConfigProvider>
   );
 };
 

--- a/src/components/FullScreenModal.tsx
+++ b/src/components/FullScreenModal.tsx
@@ -1,38 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Modal } from "antd";
 import AgreementHtml from "../AgreementHtml";
 import { MdFullscreen } from "react-icons/md";
-import useAppStore from "../store/store";
 
 const FullScreenModal: React.FC = () => {
   const [open, setOpen] = useState<boolean>(false);
-  const textColor = useAppStore((state) => state.textColor);
-  const backgroundColor = useAppStore((state) => state.backgroundColor);
-
-  useEffect(() => {
-    const style = document.createElement("style");
-    style.innerHTML = `
-      .ant-modal-content {
-        background-color: ${backgroundColor} !important;
-        color: ${textColor} !important;
-      }
-      .ant-modal-header {
-        background-color: ${backgroundColor} !important;
-        color: ${textColor} !important;
-      }
-      .ant-modal-title {
-        color: ${textColor} !important;
-      }
-      /* Fixes invisible close button in dark mode */
-      .ant-modal-close {
-        color: ${textColor} !important;
-      }
-    `;
-    document.head.appendChild(style);
-    return () => {
-      document.head.removeChild(style);
-    };
-  }, [textColor, backgroundColor]);
 
   return (
     <>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Modal, Switch, Collapse, Space, Divider, Typography, Row, Col } from 'antd';
+import { Modal, Switch, Collapse, Space, Divider, Typography, Row, Col, ConfigProvider, theme } from 'antd';
 import { BulbOutlined, MoonOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons';
 import useAppStore from '../store/store';
 import AIConfigSection from './AIConfigSection';
@@ -114,23 +114,27 @@ const SettingsModal: React.FC = () => {
   ];
 
   return (
-    <Modal
-      title="Settings"
-      open={isSettingsOpen}
-      onCancel={() => setSettingsOpen(false)}
-      footer={null}
-      className={isDarkMode ? 'dark-modal' : ''}
-      width="90%"
-      style={{ maxWidth: 520 }}
+    <ConfigProvider
+      theme={{
+        algorithm: isDarkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
+      }}
     >
-      <Collapse
-        activeKey={activeKey}
-        onChange={setActiveKey}
-        items={collapseItems}
-        bordered={false}
-        className={isDarkMode ? 'dark-collapse' : ''}
-      />
-    </Modal>
+      <Modal
+        title="Settings"
+        open={isSettingsOpen}
+        onCancel={() => setSettingsOpen(false)}
+        footer={null}
+        width="90%"
+        style={{ maxWidth: 520 }}
+      >
+        <Collapse
+          activeKey={activeKey}
+          onChange={setActiveKey}
+          items={collapseItems}
+          bordered={false}
+        />
+      </Modal>
+    </ConfigProvider>
   );
 };
 

--- a/src/tests/components/SettingsModal.test.tsx
+++ b/src/tests/components/SettingsModal.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SettingsModal from '../../components/SettingsModal';
+import useAppStore from '../../store/store';
 
 // Mock the store - use inline functions to avoid hoisting issues
 vi.mock('../../store/store', () => {
@@ -109,5 +110,28 @@ describe('SettingsModal', () => {
 
     expect(screen.getByTestId('ai-config-section')).toBeInTheDocument();
     expect(screen.getByText('AI Configuration Content')).toBeInTheDocument();
+  });
+
+  it('renders properly in dark mode state', () => {
+    const useAppStoreMock = vi.mocked(useAppStore);
+    useAppStoreMock.mockImplementation((selector: any) =>
+      selector({
+        isSettingsOpen: true,
+        setSettingsOpen: vi.fn(),
+        showLineNumbers: true,
+        setShowLineNumbers: vi.fn(),
+        textColor: '#ffffff',
+        backgroundColor: '#121212',
+        toggleDarkMode: vi.fn(),
+        keyProtectionLevel: 'none',
+        setKeyProtectionLevel: vi.fn(),
+      })
+    );
+
+    render(<SettingsModal />);
+
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Dark Mode')).toBeInTheDocument();
+    expect(screen.getByTestId('dark-mode-toggle')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Closes #965 

This PR resolves contrast and visibility issues in the Settings Modal when Dark Mode is enabled.

### Changes
- Wrapped the application in `src/App.tsx` with Ant Design's `<ConfigProvider>` using `theme.darkAlgorithm` and `theme.defaultAlgorithm` depending on dark mode state.
- Wrapped `<Modal>` in `src/components/SettingsModal.tsx` with `<ConfigProvider>` so Typography text, Form item labels, Collapse items, Checkboxes, Select dropdowns, and Buttons automatically inherit dark theme color tokens.
- Removed imperative global CSS style injection from `src/components/FullScreenModal.tsx` in favor of Ant Design `ConfigProvider` theming.
- Added a unit test in `src/tests/components/SettingsModal.test.tsx` to verify dark mode state rendering.

### Screenshots or Video
Light mode
<img width="1792" height="1037" alt="Screenshot From 2026-08-30 22-35-15" src="https://github.com/user-attachments/assets/4f385686-4e1d-4fee-8e15-5e678d9dec22" />
Dark Mode Before
<img width="1792" height="1037" alt="Screenshot From 2026-08-30 22-35-31" src="https://github.com/user-attachments/assets/f5448760-b159-48c8-b210-a8d7532d47b4" />
Dark Mode After
<img width="1792" height="1037" alt="Screenshot From 2026-08-30 22-44-14" src="https://github.com/user-attachments/assets/db2afd20-f9ba-4a69-9438-83cb49584a11" />



### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:fix/settings-modal-dark-mode`
