### PR TITLE
fix(ai): provide in-chat feedback for unconfigured AI provider

### DIFF
--- a/src/ai-assistant/chatRelay.ts
+++ b/src/ai-assistant/chatRelay.ts
@@ -132,10 +132,16 @@ export const sendMessage = async (
   const signal = newAbortController.signal;
 
   if (!aiConfig) {
-    const error = new Error('Please configure AI settings first');
+    const error = new Error('Please configure AI settings in Settings (top-right gear icon) first');
     if (onError) {
       onError(error);
     } else if (addToChat) {
+      const userMessage: Message = {
+        id: uuidv4(),
+        role: 'user',
+        content: userInput,
+        timestamp: new Date(),
+      };
       const errorMessage: Message = {
         id: uuidv4(),
         role: 'assistant',
@@ -144,7 +150,7 @@ export const sendMessage = async (
       };
 
       const updatedChatState = {
-        messages: [...chatState.messages, errorMessage],
+        messages: [...chatState.messages, userMessage, errorMessage],
         isLoading: false,
         error: null
       };

--- a/src/components/AIChatPanel.tsx
+++ b/src/components/AIChatPanel.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
+import { Alert, Button, Space, Typography } from "antd";
+import { SettingOutlined } from "@ant-design/icons";
 import useAppStore from "../store/store";
 import { sendMessage, stopMessage } from "../ai-assistant/chatRelay";
 
@@ -84,11 +86,6 @@ export const AIChatPanel = () => {
   
   const handleSendMessage = async () => {
     if (!userInput.trim()) return;
-    
-    if (!aiConfig) {
-      setSettingsOpen(true);
-      return;
-    }
     
     const prompt = userInput;
     
@@ -312,6 +309,30 @@ export const AIChatPanel = () => {
       </div>
       <div className="w-full h-[calc(100%-3rem)] flex flex-col">
         <div className="flex-1 overflow-y-auto mb-4 px-2 mt-4">
+          {!aiConfig && (
+            <div className="mb-3">
+              <Alert
+                message="AI Provider Not Configured"
+                description={
+                  <Space direction="vertical" size={8} style={{ width: '100%', marginTop: 4 }}>
+                    <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+                      Please configure an AI provider and API key in Settings to start using the assistant.
+                    </Typography.Text>
+                    <Button
+                      type="primary"
+                      size="small"
+                      icon={<SettingOutlined />}
+                      onClick={() => setSettingsOpen(true)}
+                    >
+                      Configure Settings
+                    </Button>
+                  </Space>
+                }
+                type="warning"
+                showIcon
+              />
+            </div>
+          )}
           <div className="space-y-2">
             {chatState.messages.length === 0 ? (
               <div className="w-full">

--- a/src/tests/components/AIChatPanel.test.tsx
+++ b/src/tests/components/AIChatPanel.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { AIChatPanel } from "../../components/AIChatPanel";
+import useAppStore from "../../store/store";
+
+// Mock scrollIntoView for Monaco / DOM elements in jsdom
+Element.prototype.scrollIntoView = vi.fn();
+
+describe("AIChatPanel", () => {
+  beforeEach(() => {
+    // Reset store state before each test
+    const store = useAppStore.getState();
+    store.setAIConfig(null);
+    store.setChatState({
+      messages: [],
+      isLoading: false,
+      error: null,
+    });
+    store.setSettingsOpen(false);
+  });
+
+  it("renders warning banner when AI settings are not configured", () => {
+    render(<AIChatPanel />);
+
+    expect(screen.getByText("AI Provider Not Configured")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Please configure an AI provider and API key in Settings to start using the assistant/i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Configure Settings/i })
+    ).toBeInTheDocument();
+  });
+
+  it("opens settings modal when clicking Configure Settings button on warning banner", () => {
+    render(<AIChatPanel />);
+
+    const configureBtn = screen.getByRole("button", { name: /Configure Settings/i });
+    fireEvent.click(configureBtn);
+
+    expect(useAppStore.getState().isSettingsOpen).toBe(true);
+  });
+
+  it("submits prompt and adds user message and error message when AI config is missing", async () => {
+    render(<AIChatPanel />);
+
+    const textarea = screen.getByPlaceholderText("Type your message...");
+    fireEvent.change(textarea, { target: { value: "Hello AI" } });
+
+    const sendBtn = screen.getByRole("button", { name: "Send" });
+    fireEvent.click(sendBtn);
+
+    await waitFor(() => {
+      const messages = useAppStore.getState().chatState.messages;
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+      expect(messages[0].content).toBe("Hello AI");
+      expect(messages[1].content).toContain("Please configure AI settings");
+    });
+  });
+});


### PR DESCRIPTION
Closes #968 

Summary
When opening the AI chat panel without configuring an AI provider/API key first, typing a message and hitting Enter used to pop open the Settings modal unexpectedly without showing any error in the chat.

This PR fixes that behavior so the app keeps the chat context open, shows an inline warning banner, keeps the user's message in the chat, and explains clearly that AI settings need to be configured.

Changes
Removed Abrupt Redirect: Removed if (!aiConfig) { setSettingsOpen(true); return; } from handleSendMessage in AIChatPanel.tsx.
Added Warning Banner: Displayed an Ant Design Alert banner at the top of the AI Chat panel when AI settings are missing, including a button to manually open Settings.
Improved Error Feedback: Updated sendMessage in chatRelay.ts to preserve the user's prompt in the chat history alongside an assistant error message explaining how to configure AI settings.
Added Unit Tests: Created AIChatPanel.test.tsx to test banner rendering, the "Configure Settings" button action, and message submission handling when AI settings are unconfigured.

Flags
None (No breaking changes; relies on existing Ant Design components and Zustand store).

Video
Before
[Screencast from 01-09-26 04:27:29 PM IST.webm](https://github.com/user-attachments/assets/9ff22e8d-589d-4ff7-b92f-3148987455c0)

After
[Screencast from 01-09-26 04:51:48 PM IST.webm](https://github.com/user-attachments/assets/d3b55f80-9404-4565-b4af-bc54c394b540)

Author Checklist
 Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the --signoff option of git commit.
 Vital features and changes captured in unit and/or integration tests
 Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
 Extend the documentation, if necessary
 Merging to main from fork:fix/ai-chat-unconfigured-provider-feedback