### PR TITLE
feat: design-v2-start

### DIFF
--- a/src/components/designV2/DesignV2Layout.css
+++ b/src/components/designV2/DesignV2Layout.css
@@ -17,8 +17,12 @@
   --nd-line-soft: #edf4f5;
   --nd-surface: #f8fbfb;
   --nd-placeholder: rgba(15, 32, 39, 0.08);
+  --nd-amber: #a5620c;
+  --nd-amber-tint: #fdeedc;
+  --nd-blue: #1a6bb8;
   --nd-font: "IBM Plex Sans", system-ui, sans-serif;
   --nd-mono: "IBM Plex Mono", ui-monospace, monospace;
+  --nd-serif: "IBM Plex Serif", Georgia, serif;
 
   font-family: var(--nd-font);
   font-size: 14px;
@@ -200,7 +204,7 @@
 .nd-hero-actions { position: relative; display: flex; align-items: center; gap: 18px; flex-wrap: wrap; margin-top: 4px; }
 .nd-hero-strip {
   position: relative; display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
-  padding-top: 18px; font-family: "IBM Plex Serif", Georgia, serif; font-size: 15px; color: #93b4bd;
+  padding-top: 18px; font-family: var(--nd-serif); font-size: 15px; color: #93b4bd;
 }
 .nd-hero-strip-item { display: inline-flex; align-items: center; gap: 14px; }
 .nd-hero-arrow { color: rgba(147, 180, 189, 0.6); font-family: system-ui, sans-serif; font-size: 13px; }
@@ -220,12 +224,62 @@
   grid-template-rows: minmax(0, 1fr); gap: 14px;
 }
 .nd-sample-card {
+  --nd-spine: var(--nd-teal);
   text-align: left; min-height: 0; max-height: 268px;
-  background: #fff; border: 1px solid var(--nd-line); border-radius: 12px; padding: 0;
+  background: #fff; border: 1px solid #e5eff0; border-radius: 12px; padding: 0;
+  box-shadow: 0 1px 2px rgba(15, 32, 39, 0.04);
   cursor: pointer; display: flex; flex-direction: column; overflow: hidden;
+  font: inherit; color: inherit;
   transition: transform 220ms cubic-bezier(0.2, 0.7, 0.3, 1), box-shadow 220ms ease, border-color 220ms ease;
 }
 .nd-sample-card:hover { transform: translateY(-3px); box-shadow: 0 16px 34px rgba(7, 35, 48, 0.14); border-color: #9fd6dc; }
+.nd-sample-card:focus-visible { outline: 2px solid var(--nd-teal); outline-offset: 2px; }
+.nd-sample-card-selected,
+.nd-sample-card-selected:hover { border-color: #12707b; box-shadow: 0 0 0 3px #dcebec; }
+.nd-sample-card-teal { --nd-spine: var(--nd-teal); }
+.nd-sample-card-amber { --nd-spine: var(--nd-amber); }
+.nd-sample-card-blue { --nd-spine: var(--nd-blue); }
+
+/* Miniature document at the top of the card */
+.nd-sample-thumb { flex: 1; min-height: 0; display: flex; background: #f2f7f8; padding: 11px 12px 0; overflow: hidden; }
+.nd-sample-page {
+  flex: 1; min-width: 0; display: flex; flex-direction: column;
+  background: #fff; border: 1px solid #e3edef; border-top: 3px solid var(--nd-spine);
+  border-radius: 4px 4px 0 0; padding: 10px 12px 0; overflow: hidden;
+}
+.nd-sample-body {
+  flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 4px;
+  font-family: var(--nd-serif); font-size: 10.5px; line-height: 1.5; color: var(--nd-text-3);
+  overflow: hidden;
+  mask-image: linear-gradient(#000 82%, transparent 100%);
+  -webkit-mask-image: linear-gradient(#000 82%, transparent 100%);
+}
+.nd-sample-body span { min-height: 7px; }
+
+/* Name, step count and tags under the document */
+.nd-sample-foot { flex: none; padding: 9px 13px; display: flex; flex-direction: column; gap: 5px; border-top: 1px solid var(--nd-line-soft); }
+.nd-sample-foot-row { display: flex; align-items: baseline; gap: 8px; }
+.nd-sample-foot-tags { align-items: center; gap: 5px; }
+.nd-sample-name {
+  flex: 1; min-width: 0; font-weight: 600; font-size: 13.5px; letter-spacing: -0.02em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.nd-sample-steps { flex: none; font-size: 10px; color: var(--nd-muted); white-space: nowrap; }
+.nd-sample-tick {
+  flex: none; width: 16px; height: 16px; border-radius: 50%;
+  background: var(--nd-teal); color: #fff; font-size: 9px; font-weight: 600;
+  display: flex; align-items: center; justify-content: center; align-self: center;
+}
+.nd-sample-note { flex: none; font-size: 10px; font-weight: 600; color: var(--nd-text-4); white-space: nowrap; }
+.nd-sample-card-logic .nd-sample-note { color: var(--nd-teal); }
+
+.nd-tag {
+  font-family: var(--nd-mono); font-size: 9.5px; font-weight: 500;
+  border-radius: 5px; padding: 2px 6px; white-space: nowrap;
+}
+.nd-tag-text { background: var(--nd-amber-tint); color: var(--nd-amber); }
+.nd-tag-model { background: var(--nd-teal-tint); color: var(--nd-teal); }
+.nd-tag-logic { background: #e6eef1; color: #0a4a62; }
 
 /* Editor steps */
 .nd-view-editor { align-items: stretch; }

--- a/src/components/designV2/Header.tsx
+++ b/src/components/designV2/Header.tsx
@@ -1,6 +1,7 @@
 import { Button, Dropdown, type MenuProps } from "antd";
 import { QuestionOutlined, UserOutlined, InfoOutlined, BookOutlined, CaretDownFilled } from "@ant-design/icons";
 import useAppStore from "../../store/store";
+import useDesignV2Store from "../../store/designV2Store";
 import { STEPS, type DesignV2View } from "../../types/designV2.types";
 import { HEADER, URLS } from "./constants";
 
@@ -37,10 +38,14 @@ interface HeaderProps {
   onTogglePreview: () => void;
 }
 
-/** White header: eyebrow + sample name row, followed by the stepper (one entry per item in STEPS). */
+/**
+ * White header: eyebrow + sample name row, followed by the stepper (one entry per item in STEPS).
+ * The name row shows the template picked on the Start step, falling back to the loaded sample.
+ */
 const Header = ({ view, previewOpen, onNavigate, onTogglePreview }: HeaderProps) => {
   const showChrome = view !== "welcome";
   const sampleName = useAppStore((s) => s.sampleName);
+  const selectedTemplate = useDesignV2Store((s) => s.selectedTemplate);
 
   return (
     <header className="nd-header">
@@ -49,7 +54,7 @@ const Header = ({ view, previewOpen, onNavigate, onTogglePreview }: HeaderProps)
           <div className="nd-eyebrow">{HEADER.eyebrow}</div>
           {showChrome && (
             <div className="nd-header-sample">
-              <span className="nd-header-sample-name">{sampleName}</span>
+              <span className="nd-header-sample-name">{selectedTemplate ?? sampleName}</span>
             </div>
           )}
         </div>

--- a/src/components/designV2/constants.ts
+++ b/src/components/designV2/constants.ts
@@ -88,12 +88,86 @@ export const START = {
   title: "Choose a template type",
   hint: "everything stays editable later",
   blank: "+ Blank",
+  blankName: "Blank template",
   draftWithAi: "✦ Draft with AI",
   includeLogic: "include logic",
-  includeLogicHint: (dataStep: number, logicStep: number) => `steps ${dataStep} & ${logicStep}`,
-  sampleCardLabel: (index: number) => `Template ${index}`,
-  sampleCount: 3,
+  /** "steps 5 & 6" — the ids of the steps that only exist when logic is on. */
+  includeLogicHint: (stepIds: readonly number[]) => `steps ${stepIds.join(" & ")}`,
+  stepsLabel: (count: number) => `${count} steps`,
+  cardLabel: (name: string, steps: string, note: string) => `${name} · ${steps} · ${note}`,
+  notes: { startHere: "start here", noLogic: "no logic" },
+  tags: { text: "text", model: "model", logic: "logic" },
 } as const;
+
+export type StartAccent = "teal" | "amber" | "blue";
+
+/** One card in the "Choose a template type" gallery. */
+export interface StartSample {
+  /** Short display name on the card. */
+  name: string;
+  /** NAME of the matching sample in src/samples, loaded when the user starts with this template. */
+  sampleName: string;
+  /** Colour of the page spine and, for logic templates, the note. */
+  accent: StartAccent;
+  /** Whether picking this card turns the logic steps on. */
+  logic: boolean;
+  /** Short label under the tags ("start here", "no logic"). */
+  note: string;
+  /**
+   * Preview lines: key facts from the sample's DATA ("Role: …"), then one
+   * sentence from its template, so the card is scannable and truthful.
+   * An empty string is a paragraph break.
+   */
+  body: readonly string[];
+}
+
+/** Gallery cards shown on the Start step. Loading the matching sample comes later. */
+export const START_SAMPLES: readonly StartSample[] = [
+  {
+    name: "Counter Contract",
+    sampleName: "Counter Contract (with Logic)",
+    accent: "teal",
+    logic: true,
+    note: START.notes.startHere,
+    body: [
+      "Owner: Alice",
+      "Maximum allowed count: 10",
+      "",
+      "This contract tracks a counter for Alice.",
+      "Each request increments the counter by a specified amount.",
+      "The counter cannot exceed 10.",
+    ],
+  },
+  {
+    name: "Employment Offer",
+    sampleName: "Employment Offer Letter",
+    accent: "amber",
+    logic: false,
+    note: START.notes.noLogic,
+    body: [
+      "Role: Junior AI Engineer",
+      "Company: Accord Project",
+      "Salary: 85,000 USD / year",
+      "Start date: 1 February 2025",
+      "",
+      "We are pleased to offer you the position of Junior AI Engineer.",
+    ],
+  },
+  {
+    name: "Non-disclosure",
+    sampleName: "Non-Disclosure Agreement",
+    accent: "blue",
+    logic: false,
+    note: START.notes.noLogic,
+    body: [
+      "Parties: Accord Project · John Doe",
+      "Term: 24 months",
+      "Purpose: evaluating a potential business collaboration",
+      "",
+      "This Agreement shall remain in effect for 24 months from the effective date.",
+    ],
+  },
+];
 
 export interface EditorMeta {
   icon: string;

--- a/src/components/designV2/views.tsx
+++ b/src/components/designV2/views.tsx
@@ -1,8 +1,28 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "antd";
 import HelpRail from "./HelpRail";
-import { STEPS, STEP_ID, STEP_KEY, isEditorStep, type EditorStepKey, type DesignV2View } from "../../types/designV2.types";
-import { ROUTES, WELCOME, START, EDITOR, SIMULATE, DEPLOY, type EditorMeta } from "./constants";
+import useDesignV2Store from "../../store/designV2Store";
+import {
+  STEPS,
+  STEP_ID,
+  STEP_KEY,
+  isEditorStep,
+  countStepsAfterTemplate,
+  LOGIC_ONLY_STEP_KEYS,
+  type EditorStepKey,
+  type DesignV2View,
+} from "../../types/designV2.types";
+import {
+  ROUTES,
+  WELCOME,
+  START,
+  START_SAMPLES,
+  EDITOR,
+  SIMULATE,
+  DEPLOY,
+  type EditorMeta,
+  type StartSample,
+} from "./constants";
 
 /*
  * Placeholder views for each step of the flow. Only structure — no real
@@ -56,27 +76,104 @@ export const WelcomeView = ({ onStart }: WelcomeViewProps) => {
   );
 };
 
+interface SampleCardProps {
+  sample: StartSample;
+  selected: boolean;
+  onPick: () => void;
+}
+
+/** One gallery card: a miniature document on top, name / steps / tags underneath. */
+const SampleCard = ({ sample, selected, onPick }: SampleCardProps) => {
+  const steps = START.stepsLabel(countStepsAfterTemplate(sample.logic));
+  const tags = sample.logic
+    ? [START.tags.text, START.tags.model, START.tags.logic]
+    : [START.tags.text, START.tags.model];
+  const classes = [
+    "nd-sample-card",
+    `nd-sample-card-${sample.accent}`,
+    sample.logic ? "nd-sample-card-logic" : "",
+    selected ? "nd-sample-card-selected" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      type="button"
+      className={classes}
+      aria-pressed={selected}
+      aria-label={START.cardLabel(sample.name, steps, sample.note)}
+      onClick={onPick}
+    >
+      <div className="nd-sample-thumb">
+        <div className="nd-sample-page">
+          <div className="nd-sample-body">
+            {sample.body.map((line, i) => (
+              <span key={i}>{line}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="nd-sample-foot">
+        <div className="nd-sample-foot-row">
+          <span className="nd-sample-name">{sample.name}</span>
+          <span className="nd-mono nd-sample-steps">{steps}</span>
+          {selected && <span className="nd-sample-tick" aria-hidden="true">✓</span>}
+        </div>
+        <div className="nd-sample-foot-row nd-sample-foot-tags">
+          {tags.map((tag) => (
+            <span key={tag} className={`nd-tag nd-tag-${tag}`}>{tag}</span>
+          ))}
+          <span className="nd-spacer" />
+          <span className="nd-sample-note">{sample.note}</span>
+        </div>
+      </div>
+    </button>
+  );
+};
+
 /** "Choose a template type" gallery with sample cards. */
-export const StartView = () => (
-  <div className="nd-view nd-view-start">
-    <div className="nd-start-head">
-      <span className="nd-start-title">{START.title}</span>
-      <span className="nd-start-hint">{START.hint}</span>
-      <div className="nd-spacer" />
-      <Button type="dashed" size="small">{START.blank}</Button>
-      <Button size="small">{START.draftWithAi}</Button>
-      <label className="nd-checkbox">
-        <input type="checkbox" defaultChecked /> {START.includeLogic}{" "}
-        <span className="nd-start-hint">{START.includeLogicHint(STEP_ID.data, STEP_ID.logic)}</span>
-      </label>
+export const StartView = () => {
+  const selectedTemplate = useDesignV2Store((s) => s.selectedTemplate);
+  const includeLogic = useDesignV2Store((s) => s.includeLogic);
+  const selectTemplate = useDesignV2Store((s) => s.selectTemplate);
+  const setIncludeLogic = useDesignV2Store((s) => s.setIncludeLogic);
+
+  return (
+    <div className="nd-view nd-view-start">
+      <div className="nd-start-head">
+        <span className="nd-start-title">{START.title}</span>
+        <span className="nd-start-hint">{START.hint}</span>
+        <div className="nd-spacer" />
+        <Button type="dashed" size="small" onClick={() => selectTemplate(START.blankName)}>
+          {START.blank}
+        </Button>
+        <Button size="small">{START.draftWithAi}</Button>
+        <label className="nd-checkbox">
+          <input
+            type="checkbox"
+            checked={includeLogic}
+            onChange={(e) => setIncludeLogic(e.target.checked)}
+          />{" "}
+          {START.includeLogic}{" "}
+          <span className="nd-start-hint">
+            {START.includeLogicHint(LOGIC_ONLY_STEP_KEYS.map((key) => STEP_ID[key]))}
+          </span>
+        </label>
+      </div>
+      <div className="nd-sample-grid">
+        {START_SAMPLES.map((sample) => (
+          <SampleCard
+            key={sample.name}
+            sample={sample}
+            selected={selectedTemplate === sample.name}
+            onPick={() => selectTemplate(sample.name, sample.logic)}
+          />
+        ))}
+      </div>
     </div>
-    <div className="nd-sample-grid">
-      {Array.from({ length: START.sampleCount }).map((_, i) => (
-        <button key={i} type="button" className="nd-sample-card" aria-label={START.sampleCardLabel(i + 1)} />
-      ))}
-    </div>
-  </div>
-);
+  );
+};
 
 interface EditorViewProps {
   step: EditorStepKey;

--- a/src/store/designV2Store.ts
+++ b/src/store/designV2Store.ts
@@ -14,6 +14,10 @@ export interface DesignV2State {
   view: DesignV2View;
   /** Whether the right-hand preview drawer is open. */
   previewOpen: boolean;
+  /** Name of the template card picked on the Start step; null until the user picks one. */
+  selectedTemplate: string | null;
+  /** Whether the logic steps are part of the flow (see LOGIC_ONLY_STEP_KEYS). */
+  includeLogic: boolean;
 
   setView: (view: DesignV2View) => void;
   /** Leave the welcome hero and open the first step. */
@@ -22,6 +26,12 @@ export interface DesignV2State {
   goNext: () => void;
   setPreviewOpen: (open: boolean) => void;
   togglePreview: () => void;
+  /**
+   * Pick a template card. When the card declares whether it ships logic,
+   * the "include logic" toggle follows it; otherwise the toggle is left alone.
+   */
+  selectTemplate: (name: string, logic?: boolean) => void;
+  setIncludeLogic: (on: boolean) => void;
 }
 
 const stepIndexOf = (view: DesignV2View) => STEPS.findIndex((s) => s.id === view);
@@ -31,6 +41,8 @@ const useDesignV2Store = create<DesignV2State>()(
     (set, get) => ({
       view: "welcome",
       previewOpen: false,
+      selectedTemplate: null,
+      includeLogic: true,
 
       setView: (view) => set({ view }, false, "designV2/setView"),
       start: () => set({ view: FIRST_STEP }, false, "designV2/start"),
@@ -47,6 +59,13 @@ const useDesignV2Store = create<DesignV2State>()(
       setPreviewOpen: (open) => set({ previewOpen: open }, false, "designV2/setPreviewOpen"),
       togglePreview: () =>
         set((state) => ({ previewOpen: !state.previewOpen }), false, "designV2/togglePreview"),
+      selectTemplate: (name, logic) =>
+        set(
+          (state) => ({ selectedTemplate: name, includeLogic: logic ?? state.includeLogic }),
+          false,
+          "designV2/selectTemplate"
+        ),
+      setIncludeLogic: (on) => set({ includeLogic: on }, false, "designV2/setIncludeLogic"),
     }),
     { name: "DesignV2Store" }
   )

--- a/src/tests/components/designV2/StartView.test.tsx
+++ b/src/tests/components/designV2/StartView.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StartView } from '../../../components/designV2/views';
+import useDesignV2Store from '../../../store/designV2Store';
+import { START, START_SAMPLES } from '../../../components/designV2/constants';
+import { countStepsAfterTemplate, LOGIC_ONLY_STEP_KEYS, STEP_ID } from '../../../types/designV2.types';
+import { SAMPLES } from '../../../samples';
+
+/**
+ * Covers the "Choose a template type" gallery: one card per START_SAMPLES
+ * entry, picking a card selects it (and follows its logic flag), and the
+ * Blank / include-logic controls update the v2 store.
+ */
+describe('START_SAMPLES', () => {
+  it('every card points at a real sample in src/samples', () => {
+    const names = SAMPLES.map((s) => s.NAME);
+    for (const card of START_SAMPLES) {
+      expect(names).toContain(card.sampleName);
+    }
+  });
+
+  it('cards that turn logic on point at samples that ship logic', () => {
+    for (const card of START_SAMPLES) {
+      const sample = SAMPLES.find((s) => s.NAME === card.sampleName)!;
+      expect(Boolean(sample.LOGIC)).toBe(card.logic);
+    }
+  });
+});
+
+describe('StartView', () => {
+  beforeEach(() => {
+    useDesignV2Store.setState({ selectedTemplate: null, includeLogic: true });
+  });
+
+  const cards = () => screen.getAllByRole('button', { pressed: false }).concat(
+    screen.queryAllByRole('button', { pressed: true })
+  );
+
+  it('renders one card per sample with its name, step count and note', () => {
+    render(<StartView />);
+    for (const sample of START_SAMPLES) {
+      expect(screen.getByText(sample.name)).toBeInTheDocument();
+      const steps = START.stepsLabel(countStepsAfterTemplate(sample.logic));
+      expect(
+        screen.getByRole('button', { name: START.cardLabel(sample.name, steps, sample.note) })
+      ).toBeInTheDocument();
+    }
+    expect(cards()).toHaveLength(START_SAMPLES.length);
+  });
+
+  it('starts with no card selected', () => {
+    render(<StartView />);
+    expect(screen.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+  });
+
+  it('picking a card selects it and follows its logic flag', () => {
+    render(<StartView />);
+    const noLogic = START_SAMPLES.find((s) => !s.logic)!;
+    const withLogic = START_SAMPLES.find((s) => s.logic)!;
+
+    fireEvent.click(screen.getByText(noLogic.name));
+    expect(useDesignV2Store.getState().selectedTemplate).toBe(noLogic.name);
+    expect(useDesignV2Store.getState().includeLogic).toBe(false);
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(screen.getAllByRole('button', { pressed: true })).toHaveLength(1);
+
+    fireEvent.click(screen.getByText(withLogic.name));
+    expect(useDesignV2Store.getState().selectedTemplate).toBe(withLogic.name);
+    expect(useDesignV2Store.getState().includeLogic).toBe(true);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(screen.getAllByRole('button', { pressed: true })).toHaveLength(1);
+  });
+
+  it('"+ Blank" selects the blank template without touching the logic toggle', () => {
+    render(<StartView />);
+    fireEvent.click(screen.getByRole('button', { name: START.blank }));
+    expect(useDesignV2Store.getState().selectedTemplate).toBe(START.blankName);
+    expect(useDesignV2Store.getState().includeLogic).toBe(true);
+    expect(screen.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+  });
+
+  it('the include-logic hint names the logic-only steps', () => {
+    render(<StartView />);
+    const ids = LOGIC_ONLY_STEP_KEYS.map((key) => STEP_ID[key]);
+    expect(screen.getByText(`steps ${ids.join(' & ')}`)).toBeInTheDocument();
+    expect(screen.getByText('steps 5 & 6')).toBeInTheDocument();
+  });
+
+  it('the include-logic checkbox writes to the store', () => {
+    render(<StartView />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(useDesignV2Store.getState().includeLogic).toBe(false);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(useDesignV2Store.getState().includeLogic).toBe(true);
+  });
+});

--- a/src/tests/store/designV2Store.test.ts
+++ b/src/tests/store/designV2Store.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import useDesignV2Store from '../../store/designV2Store';
-import { STEPS, FIRST_STEP, LAST_STEP } from '../../types/designV2.types';
+import { STEPS, FIRST_STEP, LAST_STEP, countStepsAfterTemplate, LOGIC_ONLY_STEP_KEYS } from '../../types/designV2.types';
 
 describe('useDesignV2Store', () => {
   beforeEach(() => {
-    useDesignV2Store.setState({ view: 'welcome', previewOpen: false });
+    useDesignV2Store.setState({ view: 'welcome', previewOpen: false, selectedTemplate: null, includeLogic: true });
   });
 
   it('starts on the welcome view with the preview closed', () => {
@@ -57,5 +57,47 @@ describe('useDesignV2Store', () => {
     expect(useDesignV2Store.getState().previewOpen).toBe(false);
     store.setPreviewOpen(true);
     expect(useDesignV2Store.getState().previewOpen).toBe(true);
+  });
+
+  it('starts with no template selected and logic included', () => {
+    const state = useDesignV2Store.getState();
+    expect(state.selectedTemplate).toBeNull();
+    expect(state.includeLogic).toBe(true);
+  });
+
+  it('selectTemplate() records the pick and follows the logic flag when given', () => {
+    const store = useDesignV2Store.getState();
+    store.selectTemplate('Employment Offer', false);
+    expect(useDesignV2Store.getState().selectedTemplate).toBe('Employment Offer');
+    expect(useDesignV2Store.getState().includeLogic).toBe(false);
+
+    store.selectTemplate('Counter Contract', true);
+    expect(useDesignV2Store.getState().selectedTemplate).toBe('Counter Contract');
+    expect(useDesignV2Store.getState().includeLogic).toBe(true);
+  });
+
+  it('selectTemplate() without a logic flag leaves the toggle alone', () => {
+    const store = useDesignV2Store.getState();
+    store.setIncludeLogic(false);
+    store.selectTemplate('Blank template');
+    expect(useDesignV2Store.getState().selectedTemplate).toBe('Blank template');
+    expect(useDesignV2Store.getState().includeLogic).toBe(false);
+  });
+
+  it('setIncludeLogic() toggles the logic steps', () => {
+    useDesignV2Store.getState().setIncludeLogic(false);
+    expect(useDesignV2Store.getState().includeLogic).toBe(false);
+    useDesignV2Store.getState().setIncludeLogic(true);
+    expect(useDesignV2Store.getState().includeLogic).toBe(true);
+  });
+});
+
+describe('countStepsAfterTemplate', () => {
+  it('counts every step after "template" when logic is included', () => {
+    expect(countStepsAfterTemplate(true)).toBe(STEPS.length - 1);
+  });
+
+  it('skips the logic-only steps when logic is off', () => {
+    expect(countStepsAfterTemplate(false)).toBe(STEPS.length - 1 - LOGIC_ONLY_STEP_KEYS.length);
   });
 });

--- a/src/types/designV2.types.ts
+++ b/src/types/designV2.types.ts
@@ -55,3 +55,18 @@ export const LAST_STEP: StepId = STEPS[STEPS.length - 1].id;
 
 export const isEditorStep = (key: StepKey): key is EditorStepKey =>
   (EDITOR_STEP_KEYS as readonly StepKey[]).includes(key);
+
+/** Steps that only make sense when the template includes logic. */
+export const LOGIC_ONLY_STEP_KEYS = ["logic", "simulate"] as const satisfies readonly StepKey[];
+
+/**
+ * Number of steps a user walks through after picking a template.
+ * Without logic the logic-only steps are skipped, so a plain text + model
+ * template has fewer steps than one with rules.
+ */
+export const countStepsAfterTemplate = (includeLogic: boolean): number =>
+  STEPS.filter(
+    (step) =>
+      step.key !== "template" &&
+      (includeLogic || !(LOGIC_ONLY_STEP_KEYS as readonly StepKey[]).includes(step.key))
+  ).length;


### PR DESCRIPTION
## Start step: template gallery

Implements the "Choose a template type" screen from the Design v2, on top of `feat/new-design-skeleton` (is stacked on #963 ) . Only the Start step is touched.

### Changes
- **Template cards**: the placeholder cards are replaced with the mock's cards: a miniature document with a coloured spine, name, step count, `text` / `model` / `logic` tags and a note. Preview lines use the real sample's data, and each card names the sample in `src/samples` it maps to.
- **Selection**: clicking a card selects it; the "include logic" toggle follows the card. "+ Blank" selects a blank template. State lives in the v2 store (`selectedTemplate`, `includeLogic`).
